### PR TITLE
Add support for vulnerabilities with no fix

### DIFF
--- a/src/SyncCommand.php
+++ b/src/SyncCommand.php
@@ -148,6 +148,7 @@ class SyncCommand extends Command
                   nodes {
                     securityVulnerability {
                       advisory {
+                        ghsaId
                         description
                         identifiers {
                           type


### PR DESCRIPTION
Sometimes there is no (known) fix for a vulnerability.

Before this fix the code would fail in those situations:
```
Fatal error: Uncaught TypeError: Typed property GitHubSecurityJira\SecurityAlertIssue::$safeVersion must be string, null used in /opt/ghsec-jira/src/SecurityAlertIssue.php:41
```
