### PR TITLE
feat(SyncCommand.php): Added states filter to GQL

### DIFF
--- a/src/SyncCommand.php
+++ b/src/SyncCommand.php
@@ -144,7 +144,7 @@ class SyncCommand extends Command
         $query = <<<'GQL'
             query alerts($owner: String!, $repo: String!) {
               repository(owner: $owner, name: $repo) {
-                vulnerabilityAlerts(first: 100) {
+                vulnerabilityAlerts(first: 100, states: OPEN) {
                   nodes {
                     securityVulnerability {
                       advisory {


### PR DESCRIPTION
vulnerabilityAlerts now only fetches OPEN vulnerabilities

We've been using dependabot for along time and when we started using this github action we found that it created JIRA issues for vulnerabilities that were already closed.