### PR TITLE
RAD-2847-Update SecurityAlertIssue.php

### DIFF
--- a/src/SecurityAlertIssue.php
+++ b/src/SecurityAlertIssue.php
@@ -124,6 +124,6 @@ EOT;
             return "{$this->package}:{$identifier}";
         }
 
-        return "{$this->package}:{$this->manifestPath}:{$identifier}";
+        return str_ireplace(" ","_","{$this->package}:{$this->manifestPath}:{$identifier}");
     }
 }

--- a/src/SecurityAlertIssue.php
+++ b/src/SecurityAlertIssue.php
@@ -124,6 +124,6 @@ EOT;
             return "{$this->package}:{$identifier}";
         }
 
-        return str_ireplace(" ","_","{$this->package}:{$this->manifestPath}:{$identifier}");
+        return str_ireplace(" ", "_", "{$this->package}:{$this->manifestPath}:{$identifier}");
     }
 }


### PR DESCRIPTION
[RAD-2847](https://radixiot.atlassian.net/browse/RAD-2847): replacing spaces by "_" as when some folders have spaces it causes issues.

As dependabot was implemented we start facing issues as some libraries contain spaces in its name:

<img width="1792" alt="Screen Shot 2023-02-14 at 10 55 05" src="https://user-images.githubusercontent.com/120426446/218805249-d32c159c-ba71-4cda-9846-01b85f64a479.png">
