### PR TITLE
Support for GitHub enterprise

### DIFF
--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -6,6 +6,9 @@ services:
         # Repo name (normally set automatically by the action) eg.
         # 'reload/github-security-jira'.
         GITHUB_REPOSITORY: reload/github-security-jira
+        # GitHub URLs (normally set automatically by the action)
+        GITHUB_GRAPHQL_URL: https://api.github.com/graphql
+        GITHUB_SERVER_URL: https://github.com
         # In repos, this is the 'GitHubSecurityToken' secret.
         GH_SECURITY_TOKEN: github_pat
         # In repos, this is the 'JiraApiToken' secret.

--- a/src/PullRequestIssue.php
+++ b/src/PullRequestIssue.php
@@ -33,9 +33,10 @@ class PullRequestIssue extends JiraSecurityIssue
         $this->safeVersion = \preg_filter('/.*to ([^ ]+).*/', '$1', $data['title']) ?? '';
 
         $githubRepo = \getenv('GITHUB_REPOSITORY') ?: '';
+        $githubUrl = \getenv('GITHUB_SERVER_URL') ?: '';
 
         $body = <<<EOT
-- Repository: [{$githubRepo}|https://github.com/{$githubRepo}]
+- Repository: [{$githubRepo}|{$githubUrl}/{$githubRepo}]
 - Package: {$this->package}
 - Secure version: {$this->safeVersion}
 - Pull request with more info: [#{$data['number']}|{$data['url']}]

--- a/src/PullRequestIssue.php
+++ b/src/PullRequestIssue.php
@@ -33,7 +33,7 @@ class PullRequestIssue extends JiraSecurityIssue
         $this->safeVersion = \preg_filter('/.*to ([^ ]+).*/', '$1', $data['title']) ?? '';
 
         $githubRepo = \getenv('GITHUB_REPOSITORY') ?: '';
-        $githubUrl = \getenv('GITHUB_SERVER_URL') ?: '';
+        $githubUrl = \getenv('GITHUB_SERVER_URL') ?: 'https://github.com';
 
         $body = <<<EOT
 - Repository: [{$githubRepo}|{$githubUrl}/{$githubRepo}]

--- a/src/SecurityAlertIssue.php
+++ b/src/SecurityAlertIssue.php
@@ -78,11 +78,12 @@ class SecurityAlertIssue extends JiraSecurityIssue
         $advisory_description = \wordwrap($data['securityVulnerability']['advisory']['description'] ?? '', 100);
         $ecosystem = $data['securityVulnerability']['package']['ecosystem'] ?? '';
         $githubRepo = \getenv('GITHUB_REPOSITORY') ?: '';
+        $githubUrl = \getenv('GITHUB_SERVER_URL') ?: '';
         $safeVersion = $this->safeVersion ?? 'no fix';
 
         $body = <<<EOT
-- Repository: [{$githubRepo}|https://github.com/{$githubRepo}]
-- Alert: [{$this->advisorySummary}|https://github.com/{$githubRepo}/security/dependabot/{$this->alertNumber}]
+- Repository: [{$githubRepo}|{$githubUrl}/{$githubRepo}]
+- Alert: [{$this->advisorySummary}|{$githubUrl}/{$githubRepo}/security/dependabot/{$this->alertNumber}]
 - Package: {$this->package} ($ecosystem)
 - Vulnerable version: {$this->vulnerableVersionRange}
 - Secure version: {$safeVersion}

--- a/src/SecurityAlertIssue.php
+++ b/src/SecurityAlertIssue.php
@@ -78,7 +78,7 @@ class SecurityAlertIssue extends JiraSecurityIssue
         $advisory_description = \wordwrap($data['securityVulnerability']['advisory']['description'] ?? '', 100);
         $ecosystem = $data['securityVulnerability']['package']['ecosystem'] ?? '';
         $githubRepo = \getenv('GITHUB_REPOSITORY') ?: '';
-        $githubUrl = \getenv('GITHUB_SERVER_URL') ?: '';
+        $githubUrl = \getenv('GITHUB_SERVER_URL') ?: 'https://github.com';
         $safeVersion = $this->safeVersion ?? 'no fix';
 
         $body = <<<EOT

--- a/src/SyncCommand.php
+++ b/src/SyncCommand.php
@@ -264,8 +264,8 @@ GQL;
     protected function getGHClient(): GraphQLClient
     {
         $access_token = \getenv('GH_SECURITY_TOKEN');
-
-        return ClientBuilder::build('https://api.github.com/graphql', [
+        $graphql_url = \getenv('GITHUB_GRAPHQL_URL');
+        return ClientBuilder::build($graphql_url, [
             'headers' => [
                 'Accept' => 'application/json',
                 'Authorization' => "Bearer {$access_token}",

--- a/src/SyncCommand.php
+++ b/src/SyncCommand.php
@@ -264,7 +264,7 @@ GQL;
     protected function getGHClient(): GraphQLClient
     {
         $access_token = \getenv('GH_SECURITY_TOKEN');
-        $graphql_url = \getenv('GITHUB_GRAPHQL_URL');
+        $graphql_url = \getenv('GITHUB_GRAPHQL_URL') ?: 'https://api.github.com/graphql';
         return ClientBuilder::build($graphql_url, [
             'headers' => [
                 'Accept' => 'application/json',


### PR DESCRIPTION
The GitHub URLs were hardcoded, while they are also available as env vars to the actions. Changed this and tested successfully with our enterprise GitHub.