### PR TITLE
Remove reviewers from Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,17 @@
 version: 2
-
 updates:
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: daily
-    timezone: Europe/Copenhagen
-  reviewers:
-  - "reload/developers"
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-    timezone: Europe/Copenhagen
-  reviewers:
-  - "reload/developers"
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: daily
-    timezone: Europe/Copenhagen
-  reviewers:
-  - "reload/developers"
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: daily
+      timezone: Europe/Copenhagen
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      timezone: Europe/Copenhagen
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+      timezone: Europe/Copenhagen


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
