### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,5 +1,8 @@
 on: pull_request
 name: Code style review
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   review_codestyle:
     name: Codestyle


### PR DESCRIPTION
Potential fix for [https://github.com/reload/github-security-jira/security/code-scanning/3](https://github.com/reload/github-security-jira/security/code-scanning/3)

To fix this issue, add an explicit `permissions` block to the workflow, either at the workflow (top/root) level (to apply to all jobs) or at the job level (more granular). Since both jobs use Reviewdog to report on PRs, both require `contents: read` (to check out code) and `pull-requests: write` (to interact with PRs). The best way is to add at the root, just after the workflow `name`, which applies to all jobs by default and is minimal and correct. No other permissions are needed for these jobs.

Specifically:  
- Insert a `permissions:` block after the `name: Code style review` line (line 2), with:
  - `contents: read`
  - `pull-requests: write`

No additional dependencies, configuration, or code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
