### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,5 +1,7 @@
 on: push
 name: Docker build and run
+permissions:
+  contents: read
 jobs:
   build:
     name: Docker build and run


### PR DESCRIPTION
Potential fix for [https://github.com/reload/github-security-jira/security/code-scanning/1](https://github.com/reload/github-security-jira/security/code-scanning/1)

To fix the problem, add a `permissions:` block to the workflow file. Since none of the steps require write permissions to repository contents or pull requests, the most minimal safe permission is `contents: read`. This block should be placed either at the root of the workflow YAML (to apply to all jobs), or within the specific job definition. Given that there is only one job in this workflow, it can be added at either level; the root level is typical and clear. Edit the file `.github/workflows/docker-build.yml` by adding the following block near the top (after `name:` and before `jobs:`):

```yaml
permissions:
  contents: read
```

No new methods, external imports, or other code changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
