### PR TITLE
Fix: Migrate from Jira API v2 to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "softonic/graphql-client": "^2.1",
         "symfony/console": "^5",
         "symfony/yaml": "^6.1",
-        "reload/jira-security-issue": "^2.0.11"
+        "reload/jira-security-issue": "^2.0.11",
+        "cweagans/composer-patches": "^1.7"
     },
     "repositories": [
       {
@@ -31,6 +32,13 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "phpstan/extension-installer": true,
             "cweagans/composer-patches": true
+        }
+    },
+    "extra": {
+        "patches": {
+            "lesstif/php-jira-rest-client": {
+                "Update Jira API from v2 to v3": "patches/jira-api-v3.patch"
+            }
         }
     }
 }

--- a/patches/jira-api-v3.patch
+++ b/patches/jira-api-v3.patch
@@ -1,0 +1,20 @@
+--- a/src/JiraClient.php
++++ b/src/JiraClient.php
+@@ -66,7 +66,7 @@ class JiraClient
+     /**
+      * Json Mapper.
+      */
+-    private string $api_uri = '/rest/api/2';
++    private string $api_uri = '/rest/api/3';
+
+     /**
+      * JIRA REST API URI for webhooks.
+@@ -222,7 +222,7 @@ class JiraClient
+      */
+     public function setRestApiV2(): void
+     {
+-        $this->api_uri = '/rest/api/2';
++        $this->api_uri = '/rest/api/3';
+     }
+
+     /**


### PR DESCRIPTION
- Added cweagans/composer-patches to dependencies
- Created patch to update lesstif/php-jira-rest-client to use API v3
- Changes /rest/api/2 to /rest/api/3 in JiraClient

This resolves the 410 error caused by Atlassian's removal of API v2. The patch automatically updates the underlying Jira client library without requiring a fork of that dependency.

Fixes compatibility with Atlassian Cloud Jira API v3.