### PR TITLE
Use flexible PHP version in Docker builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,13 +4,27 @@ name: Docker build and run
 permissions:
   contents: read
 jobs:
+  php-versions:
+    name: Lookup PHP versions
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.versions.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: antfroger/php-version-action@v1
+        id: versions
+
   build:
-    name: Docker build and run
+    name: Docker build and run (PHP ${{ matrix.php-version }})
+    needs: php-versions
     if: '!github.event.deleted'
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        php-version: ${{ fromJSON(needs.php-versions.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
       - name: Docker build
-        run: docker build --tag github-security-jira:latest .
+        run: docker build --build-arg PHP_VERSION=${{ matrix.php-version }} --tag github-security-jira:php${{ matrix.php-version }} .
       - name: Run in Docker
-        run: docker run -t --rm github-security-jira:latest --version
+        run: docker run -t --rm github-security-jira:php${{ matrix.php-version }} --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ ARG COMPOSER_VERSION=2
 
 # -----------------
 # Get Composer binary from official image
-FROM public.ecr.aws/docker/library/composer:${COMPOSER_VERSION} AS composer
+FROM composer:${COMPOSER_VERSION} AS composer
 
 # -----------------
 # Build stage: install dependencies using matching PHP version
-FROM public.ecr.aws/docker/library/php:${PHP_VERSION}-alpine AS build-env
+FROM php:${PHP_VERSION}-alpine AS build-env
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
@@ -20,7 +20,7 @@ RUN composer install --prefer-dist --no-dev
 
 # -----------------
 # Runtime stage
-FROM public.ecr.aws/docker/library/php:${PHP_VERSION}-alpine
+FROM php:${PHP_VERSION}-alpine
 
 COPY --from=build-env /opt/ghsec-jira/ /opt/ghsec-jira/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
+# Build arguments for version flexibility
+ARG PHP_VERSION=8.3
+ARG COMPOSER_VERSION=2
+
 # -----------------
-FROM composer:2.9.1@sha256:7384cf9fa70b710af02c9f40bec6e44472e07138efa5ab3428a058087c0d2724 AS build-env
+# Get Composer binary from official image
+FROM public.ecr.aws/docker/library/composer:${COMPOSER_VERSION} AS composer
+
+# -----------------
+# Build stage: install dependencies using matching PHP version
+FROM public.ecr.aws/docker/library/php:${PHP_VERSION}-alpine AS build-env
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 COPY . /opt/ghsec-jira/
 
@@ -8,7 +19,8 @@ WORKDIR /opt/ghsec-jira
 RUN composer install --prefer-dist --no-dev
 
 # -----------------
-FROM php:8.3.7-alpine3.18@sha256:3da837b84db645187ae2f24ca664da3faee7c546f0e8d930950b12d24f0d8fa0
+# Runtime stage
+FROM public.ecr.aws/docker/library/php:${PHP_VERSION}-alpine
 
 COPY --from=build-env /opt/ghsec-jira/ /opt/ghsec-jira/
 


### PR DESCRIPTION
## Summary

- Use build args for PHP and Composer versions, allowing version flexibility without changing the Dockerfile
- Copy Composer binary from official image into PHP base image, ensuring the PHP version used for dependency installation matches the runtime version
- Add PHP version matrix to Docker build CI workflow, testing builds with all PHP versions supported by the project (currently 8.3, 8.4)

## Motivation

PR #521 (Dependabot Composer update to 2.9.4) fails because the `composer:2.9.4` image ships with PHP 8.5.2, which exceeds the project's PHP version constraint (`>=8.3 <8.5`). By decoupling the Composer binary from its base PHP image, we can update Composer independently of PHP version changes.

Also, [the Composer people discourage relying on the PHP version](https://github.com/docker-library/docs/blob/master/composer/README.md) in their container image:

> "You should not rely on the PHP version in our container... We do not provide a Composer image for each supported PHP version."

## Test plan

- [ ] CI passes for PHP 8.3 Docker build
- [ ] CI passes for PHP 8.4 Docker build
- [ ] After merging, rebase PR #521 and verify it passes
