### PR TITLE
Adjust build process and upgrade Composer to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-# -----------------
-FROM composer:2.9.1@sha256:7384cf9fa70b710af02c9f40bec6e44472e07138efa5ab3428a058087c0d2724 AS build-env
+FROM composer:2.9.4@sha256:1872bdb4a2080390498e75e7eb55f9d7e70c689ab5ab072a01da80720a68c6da AS composer
+FROM php:8.3.7-alpine3.18@sha256:3da837b84db645187ae2f24ca664da3faee7c546f0e8d930950b12d24f0d8fa0
 
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 COPY . /opt/ghsec-jira/
 
 WORKDIR /opt/ghsec-jira
 
 RUN composer install --prefer-dist --no-dev
-
-# -----------------
-FROM php:8.3.7-alpine3.18@sha256:3da837b84db645187ae2f24ca664da3faee7c546f0e8d930950b12d24f0d8fa0
-
-COPY --from=build-env /opt/ghsec-jira/ /opt/ghsec-jira/
 
 ENTRYPOINT ["/opt/ghsec-jira/bin/ghsec-jira", "sync", "-vvv"]


### PR DESCRIPTION
This adjusts the way we build the container image and run Composer
during the build process. This allows us to upgrade to latest Composer
version, even when the official Composer image is running in an
unsupported PHP version.
