### PR TITLE
Refactor: two-way sync, extract services, add tests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -66,3 +66,23 @@ jobs:
           php -d memory_limit=1G vendor/bin/phpstan analyse . --error-format=checkstyle | ./reviewdog -f=checkstyle -name=PHPStan -reporter=github-pr-check
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-24.04
+    needs: php-versions
+    strategy:
+      matrix:
+        php-version: ${{ fromJSON(needs.php-versions.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@master
+        with:
+          php-version: ${{ matrix.php-version }}
+          coverage: none
+      - name: Install Dependencies
+        run: |
+          composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 docker-compose.override.yml
+.phpunit.cache/

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
-.PHONY: check phpstan phpcs markdownlint
+.PHONY: check phpstan phpcs phpunit markdownlint
 
-check: phpstan phpcs markdownlint
+check: phpstan phpcs phpunit markdownlint
 
 phpstan:
 	-vendor/bin/phpstan analyse .
 
 phpcs:
 	-vendor/bin/phpcs -s bin/ src/
+
+phpunit:
+	-vendor/bin/phpunit
 
 # gem install mdl
 markdownlint:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ It has some required and some optional settings, which are passed to the action 
 - `JIRA_RESTRICTED_COMMENT_ROLE`: A comment with restricted visibility
   to this role is posted with info about who was added as watchers to
   the issue. Defaults to `Developers`. (*Optional*)
+- `JIRA_CLOSE_TRANSITION`: The Jira workflow transition name used when closing resolved alerts. Defaults to `Done`. (*Optional*)
 
 Here is an example setup which runs this action every 6 hours.
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
         "php": ">=8.3 <8.5",
         "softonic/graphql-client": "^2.1",
         "symfony/console": "^5",
-        "symfony/yaml": "^6.1",
         "reload/jira-security-issue": "^2.0.11"
     },
     "repositories": [
@@ -20,8 +19,14 @@
             "GitHubSecurityJira\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "GitHubSecurityJira\\Tests\\": "tests/"
+        }
+    },
     "require-dev": {
         "phpstan/phpstan": "^1",
+        "phpunit/phpunit": "^10.5",
         "squizlabs/php_codesniffer": "^4.0",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-deprecation-rules": "^1.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,28 +4,28 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a6c5844ba1160e4dad99e1a5a64d1efb",
+    "content-hash": "f27d56919c4795d3426cfca2b98216b5",
     "packages": [
         {
             "name": "graham-campbell/result-type",
-            "version": "v1.1.3",
+            "version": "v1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GrahamCampbell/Result-Type.git",
-                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945"
+                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/3ba905c11371512af9d9bdd27d99b782216b6945",
-                "reference": "3ba905c11371512af9d9bdd27d99b782216b6945",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/e01f4a821471308ba86aa202fed6698b6b695e3b",
+                "reference": "e01f4a821471308ba86aa202fed6698b6b695e3b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
-                "phpoption/phpoption": "^1.9.3"
+                "phpoption/phpoption": "^1.9.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20 || ^10.5.28"
+                "phpunit/phpunit": "^8.5.41 || ^9.6.22 || ^10.5.45 || ^11.5.7"
             },
             "type": "library",
             "autoload": {
@@ -54,7 +54,7 @@
             ],
             "support": {
                 "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
-                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.3"
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.4"
             },
             "funding": [
                 {
@@ -66,7 +66,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-20T21:45:45+00:00"
+            "time": "2025-12-27T19:43:20+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -460,16 +460,16 @@
         },
         {
             "name": "lesstif/php-jira-rest-client",
-            "version": "5.12.0",
+            "version": "5.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lesstif/php-jira-rest-client.git",
-                "reference": "68cc07a9b188c7ac7932e9be4074dd9169bfa451"
+                "reference": "ae3903243b6d5b307f7d2de4eda5cbe7741a2250"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lesstif/php-jira-rest-client/zipball/68cc07a9b188c7ac7932e9be4074dd9169bfa451",
-                "reference": "68cc07a9b188c7ac7932e9be4074dd9169bfa451",
+                "url": "https://api.github.com/repos/lesstif/php-jira-rest-client/zipball/ae3903243b6d5b307f7d2de4eda5cbe7741a2250",
+                "reference": "ae3903243b6d5b307f7d2de4eda5cbe7741a2250",
                 "shasum": ""
             },
             "require": {
@@ -519,22 +519,22 @@
             ],
             "support": {
                 "issues": "https://github.com/lesstif/php-jira-rest-client/issues",
-                "source": "https://github.com/lesstif/php-jira-rest-client/tree/5.12.0"
+                "source": "https://github.com/lesstif/php-jira-rest-client/tree/5.12.1"
             },
-            "time": "2025-10-12T10:56:08+00:00"
+            "time": "2026-01-05T14:15:56+00:00"
         },
         {
             "name": "monolog/monolog",
-            "version": "3.9.0",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
-                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/b321dd6749f0bf7189444158a3ce785cc16d69b0",
+                "reference": "b321dd6749f0bf7189444158a3ce785cc16d69b0",
                 "shasum": ""
             },
             "require": {
@@ -552,7 +552,7 @@
                 "graylog2/gelf-php": "^1.4.2 || ^2.0",
                 "guzzlehttp/guzzle": "^7.4.5",
                 "guzzlehttp/psr7": "^2.2",
-                "mongodb/mongodb": "^1.8",
+                "mongodb/mongodb": "^1.8 || ^2.0",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
                 "php-console/php-console": "^3.1.8",
                 "phpstan/phpstan": "^2",
@@ -612,7 +612,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
+                "source": "https://github.com/Seldaek/monolog/tree/3.10.0"
             },
             "funding": [
                 {
@@ -624,20 +624,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-24T10:02:05+00:00"
+            "time": "2026-01-02T08:56:05+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v5.0.0",
+            "version": "v5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "8c64d8d444a5d764c641ebe97e0e3bc72b25bf6c"
+                "reference": "980674efdda65913492d29a8fd51c82270dd37bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8c64d8d444a5d764c641ebe97e0e3bc72b25bf6c",
-                "reference": "8c64d8d444a5d764c641ebe97e0e3bc72b25bf6c",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/980674efdda65913492d29a8fd51c82270dd37bb",
+                "reference": "980674efdda65913492d29a8fd51c82270dd37bb",
                 "shasum": ""
             },
             "require": {
@@ -673,22 +673,22 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v5.0.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v5.0.1"
             },
-            "time": "2024-09-08T10:20:00+00:00"
+            "time": "2026-02-22T16:28:03+00:00"
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.9.4",
+            "version": "1.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d"
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
-                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/75365b91986c2405cf5e1e012c5595cd487a98be",
+                "reference": "75365b91986c2405cf5e1e012c5595cd487a98be",
                 "shasum": ""
             },
             "require": {
@@ -738,7 +738,7 @@
             ],
             "support": {
                 "issues": "https://github.com/schmittjoh/php-option/issues",
-                "source": "https://github.com/schmittjoh/php-option/tree/1.9.4"
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.5"
             },
             "funding": [
                 {
@@ -750,7 +750,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-21T11:53:16+00:00"
+            "time": "2025-12-27T19:41:33+00:00"
         },
         {
             "name": "psr/cache",
@@ -2010,16 +2010,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.26",
+            "version": "v6.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "5621f039a71a11c87c106c1c598bdcd04a19aeea"
+                "reference": "2adaf4106f2ef4c67271971bde6d3fe0a6936432"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/5621f039a71a11c87c106c1c598bdcd04a19aeea",
-                "reference": "5621f039a71a11c87c106c1c598bdcd04a19aeea",
+                "url": "https://api.github.com/repos/symfony/string/zipball/2adaf4106f2ef4c67271971bde6d3fe0a6936432",
+                "reference": "2adaf4106f2ef4c67271971bde6d3fe0a6936432",
                 "shasum": ""
             },
             "require": {
@@ -2075,7 +2075,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.26"
+                "source": "https://github.com/symfony/string/tree/v6.4.34"
             },
             "funding": [
                 {
@@ -2095,106 +2095,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-11T14:32:46+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v6.4.26",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "0fc8b966fd0dcaab544ae59bfc3a433f048c17b0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/0fc8b966fd0dcaab544ae59bfc3a433f048c17b0",
-                "reference": "0fc8b966fd0dcaab544ae59bfc3a433f048c17b0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "symfony/console": "<5.4"
-            },
-            "require-dev": {
-                "symfony/console": "^5.4|^6.0|^7.0"
-            },
-            "bin": [
-                "Resources/bin/yaml-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Loads and dumps YAML files",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.26"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-09-26T15:07:38+00:00"
+            "time": "2026-02-08T20:44:54+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.2",
+            "version": "v5.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af"
+                "reference": "955e7815d677a3eaa7075231212f2110983adecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
-                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/955e7815d677a3eaa7075231212f2110983adecc",
+                "reference": "955e7815d677a3eaa7075231212f2110983adecc",
                 "shasum": ""
             },
             "require": {
                 "ext-pcre": "*",
-                "graham-campbell/result-type": "^1.1.3",
+                "graham-campbell/result-type": "^1.1.4",
                 "php": "^7.2.5 || ^8.0",
-                "phpoption/phpoption": "^1.9.3",
-                "symfony/polyfill-ctype": "^1.24",
-                "symfony/polyfill-mbstring": "^1.24",
-                "symfony/polyfill-php80": "^1.24"
+                "phpoption/phpoption": "^1.9.5",
+                "symfony/polyfill-ctype": "^1.26",
+                "symfony/polyfill-mbstring": "^1.26",
+                "symfony/polyfill-php80": "^1.26"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
@@ -2243,7 +2167,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.2"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.3"
             },
             "funding": [
                 {
@@ -2255,7 +2179,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-30T23:37:27+00:00"
+            "time": "2025-12-27T19:49:13+00:00"
         },
         {
             "name": "webignition/symfony-console-typed-input",
@@ -2319,6 +2243,242 @@
     ],
     "packages-dev": [
         {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
             "name": "phpstan/extension-installer",
             "version": "1.4.3",
             "source": {
@@ -2368,11 +2528,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.32",
+            "version": "1.12.33",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/2770dcdf5078d0b0d53f94317e06affe88419aa8",
-                "reference": "2770dcdf5078d0b0d53f94317e06affe88419aa8",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
                 "shasum": ""
             },
             "require": {
@@ -2417,7 +2577,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-30T10:16:31+00:00"
+            "time": "2026-02-28T20:30:03+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -2465,6 +2625,1389 @@
                 "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.2.1"
             },
             "time": "2024-09-11T15:52:35+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "10.1.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.1"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:31:57+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T06:24:48+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:56:09+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T14:07:24+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:57:52+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "10.5.63",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/33198268dad71e926626b618f3ec3966661e4d90",
+                "reference": "33198268dad71e926626b618f3ec3966661e4d90",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.5",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.63"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-27T05:48:37+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:12:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:58:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:59:15+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "5.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:25:16+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:37:17+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:15:17+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "6.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-23T08:47:14+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "5.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:09:11+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:19:19+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:38:20+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:08:32+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:06:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:50:56+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:10:45+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -2544,6 +4087,56 @@
                 }
             ],
             "time": "2025-11-10T16:43:36+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
         }
     ],
     "aliases": [],
@@ -2555,5 +4148,5 @@
         "php": ">=8.3 <8.5"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -21,6 +21,7 @@ services:
       JIRA_WATCHERS: |-
         someuser@reload.dk
         someotheruser@reload.dk
+      JIRA_CLOSE_TRANSITION: Done
       JIRA_RESTRICTED_GROUP: Developers
       JIRA_RESTRICTED_COMMENT: |-
         Remember to evaluate severity here and set ticket priority.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,4 @@ parameters:
     - .
     excludePaths:
     - vendor
+    - tests/Fixtures

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/AlertIdentifier.php
+++ b/src/AlertIdentifier.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira;
+
+class AlertIdentifier
+{
+    /**
+     * phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+     *
+     * Build a unique ID from alert data, matching SecurityAlertIssue::uniqueId() logic.
+     *
+     * @param array<string,mixed> $alertData
+     */
+    public static function fromAlertData(array $alertData): string
+    {
+        // phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+        $package = $alertData['securityVulnerability']['package']['name'];
+        $safeVersion = $alertData['securityVulnerability']['firstPatchedVersion']['identifier'] ?? null;
+        $ghsaId = $alertData['securityVulnerability']['advisory']['ghsaId'];
+        $manifestPath = \pathinfo($alertData['vulnerableManifestPath'], \PATHINFO_DIRNAME);
+
+        $identifier = $safeVersion ?? $ghsaId;
+
+        if ($manifestPath === '.' || $manifestPath === '/') {
+            return "{$package}:{$identifier}";
+        }
+
+        return str_ireplace(" ", "_", "{$package}:{$manifestPath}:{$identifier}");
+    }
+}

--- a/src/AlertSyncService.php
+++ b/src/AlertSyncService.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+class AlertSyncService
+{
+    private ?JiraTransitionService $jiraTransitionService = null;
+
+    public function __construct(
+        private readonly Config $config,
+        private readonly GitHubGraphQLClient $githubClient,
+        ?JiraTransitionService $jiraTransitionService = null,
+    ) {
+        $this->jiraTransitionService = $jiraTransitionService;
+    }
+
+    /**
+     * Sync open alerts to Jira and return processed unique IDs.
+     *
+     * @return array<string>
+     */
+    public function syncOpenAlerts(OutputInterface $output, bool $dryRun): array
+    {
+        $alerts = $this->githubClient->fetchOpenAlerts();
+
+        if (empty($alerts)) {
+            $this->log($output, 'No alerts found.');
+        }
+
+        $alertsFound = [];
+
+        foreach ($alerts as $alert) {
+            $issue = new SecurityAlertIssue($alert, $this->config);
+
+            $existingKey = $issue->exists();
+
+            if (!\is_null($existingKey)) {
+                $this->log($output, "Existing issue {$existingKey} covers {$issue->uniqueId()}.");
+            } elseif (!$dryRun) {
+                $key = $issue->ensure();
+                $this->log($output, "Created issue {$key} for {$issue->uniqueId()}.");
+            } else {
+                $this->log($output, "Would have created an issue for {$issue->uniqueId()} if not a dry run.");
+            }
+
+            $alertsFound[] = $issue->uniqueId();
+        }
+
+        return $alertsFound;
+    }
+
+    /**
+     * Sync Dependabot security pull requests, skipping any already covered by alerts.
+     *
+     * @param array<string> $skipIds
+     */
+    public function syncPullRequests(OutputInterface $output, bool $dryRun, array $skipIds): void
+    {
+        $pullRequests = $this->githubClient->fetchSecurityPullRequests();
+
+        foreach ($pullRequests as $pullRequest) {
+            $issue = new PullRequestIssue($pullRequest['node'], $this->config);
+
+            if (\in_array($issue->uniqueId(), $skipIds)) {
+                continue;
+            }
+
+            $existingKey = $issue->exists();
+
+            if (!\is_null($existingKey)) {
+                $this->log($output, "Existing issue {$existingKey} covers {$issue->uniqueId()}.");
+            } elseif (!$dryRun) {
+                $key = $issue->ensure();
+                $this->log($output, "Created issue {$key} for {$issue->uniqueId()}.");
+            } else {
+                $this->log($output, "Would have created an issue for {$issue->uniqueId()} if not a dry run.");
+            }
+        }
+    }
+
+    /**
+     * Find and close Jira tickets for resolved GitHub alerts.
+     */
+    public function closeResolvedAlerts(OutputInterface $output, bool $dryRun): void
+    {
+        $resolvedAlerts = $this->githubClient->fetchResolvedAlerts();
+
+        if (empty($resolvedAlerts)) {
+            $this->log($output, 'No resolved alerts found.');
+            return;
+        }
+
+        $transitionService = $this->getJiraTransitionService();
+
+        foreach ($resolvedAlerts as $alert) {
+            try {
+                $uniqueId = AlertIdentifier::fromAlertData($alert);
+                $state = $alert['state'] ?? 'UNKNOWN';
+                $package = $alert['securityVulnerability']['package']['name'] ?? 'unknown';
+                $summary = $alert['securityVulnerability']['advisory']['summary'] ?? '';
+
+                $labels = [
+                    $this->config->githubRepository,
+                    $uniqueId,
+                ];
+
+                $issueKeys = $transitionService->findIssuesByLabels($labels);
+
+                if (empty($issueKeys)) {
+                    continue;
+                }
+
+                $comment = $this->buildClosureComment($alert, $state, $package, $summary);
+
+                foreach ($issueKeys as $issueKey) {
+                    if ($dryRun) {
+                        $this->log(
+                            $output,
+                            "Would close {$issueKey} (alert {$state}) if not a dry run."
+                        );
+                        continue;
+                    }
+
+                    try {
+                        $transitionService->closeIssue($issueKey, $comment);
+                        $this->log($output, "Closed {$issueKey} — alert {$state} for {$package}.");
+                    } catch (Throwable $e) {
+                        $this->log(
+                            $output,
+                            "Failed to close {$issueKey}: {$e->getMessage()}"
+                        );
+                    }
+                }
+            } catch (Throwable $e) {
+                $this->log($output, "Error processing resolved alert: {$e->getMessage()}");
+            }
+        }
+    }
+
+    /**
+     * phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+     *
+     * @param array<string,mixed> $alert
+     */
+    private function buildClosureComment(array $alert, string $state, string $package, string $summary): string
+    {
+        // phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+        $lines = [
+            "Alert resolved: *{$state}*",
+            "Package: {$package}",
+        ];
+
+        if ($summary !== '') {
+            $lines[] = "Advisory: {$summary}";
+        }
+
+        if ($state === 'FIXED' && !empty($alert['fixedAt'])) {
+            $lines[] = "Fixed at: {$alert['fixedAt']}";
+        }
+
+        if (($state === 'DISMISSED' || $state === 'AUTO_DISMISSED') && !empty($alert['dismissedAt'])) {
+            $lines[] = "Dismissed at: {$alert['dismissedAt']}";
+        }
+
+        if (!empty($alert['dismissReason'])) {
+            $lines[] = "Dismiss reason: {$alert['dismissReason']}";
+        }
+
+        return \implode("\n", $lines);
+    }
+
+    private function getJiraTransitionService(): JiraTransitionService
+    {
+        if ($this->jiraTransitionService === null) {
+            $this->jiraTransitionService = new JiraTransitionService($this->config);
+        }
+
+        return $this->jiraTransitionService;
+    }
+
+    private function log(OutputInterface $output, string $message): void
+    {
+        if ($output->getVerbosity() < OutputInterface::VERBOSITY_VERBOSE) {
+            return;
+        }
+
+        $timestamp = \gmdate(\DATE_ATOM);
+
+        $output->writeln("{$timestamp} - {$this->config->jiraProject} - {$message}");
+    }
+}

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira;
+
+use RuntimeException;
+
+class Config
+{
+    public readonly string $githubRepository;
+    public readonly string $githubOwner;
+    public readonly string $githubRepo;
+    public readonly string $ghSecurityToken;
+    public readonly string $githubGraphqlUrl;
+    public readonly string $githubServerUrl;
+    public readonly string $jiraHost;
+    public readonly string $jiraUser;
+    public readonly string $jiraToken;
+    public readonly string $jiraProject;
+    public readonly string $jiraIssueType;
+    public readonly string $jiraRestrictedCommentRole;
+    public readonly string $jiraCloseTransition;
+    /** @var array<string> */
+    public readonly array $jiraWatchers;
+    /** @var array<string> */
+    public readonly array $jiraIssueLabels;
+
+    public function __construct()
+    {
+        $required = [
+            'GITHUB_REPOSITORY',
+            'GH_SECURITY_TOKEN',
+            'JIRA_HOST',
+            'JIRA_USER',
+            'JIRA_TOKEN',
+            'JIRA_PROJECT',
+        ];
+
+        foreach ($required as $var) {
+            $value = \getenv($var);
+            if (!\is_string($value) || $value === '') {
+                throw new RuntimeException("Required env variable '{$var}' not set or empty.");
+            }
+        }
+
+        $this->githubRepository = \getenv('GITHUB_REPOSITORY') ?: '';
+        $parts = \explode('/', $this->githubRepository);
+
+        if (\count($parts) < 2) {
+            throw new RuntimeException(
+                'GitHub repository invalid: ' . $this->githubRepository
+            );
+        }
+
+        $this->githubOwner = $parts[0];
+        $this->githubRepo = $parts[1];
+        $this->ghSecurityToken = \getenv('GH_SECURITY_TOKEN') ?: '';
+        $this->githubGraphqlUrl = \getenv('GITHUB_GRAPHQL_URL') ?: 'https://api.github.com/graphql';
+        $this->githubServerUrl = \getenv('GITHUB_SERVER_URL') ?: 'https://github.com';
+        $this->jiraHost = \getenv('JIRA_HOST') ?: '';
+        $this->jiraUser = \getenv('JIRA_USER') ?: '';
+        $this->jiraToken = \getenv('JIRA_TOKEN') ?: '';
+        $this->jiraProject = \getenv('JIRA_PROJECT') ?: '';
+        $this->jiraIssueType = \getenv('JIRA_ISSUE_TYPE') ?: 'Bug';
+        $this->jiraRestrictedCommentRole = \getenv('JIRA_RESTRICTED_COMMENT_ROLE') ?: 'Developers';
+        $this->jiraCloseTransition = \getenv('JIRA_CLOSE_TRANSITION') ?: 'Done';
+
+        $watchers = \getenv('JIRA_WATCHERS') ?: '';
+        $this->jiraWatchers = $watchers !== '' ? \array_filter(\array_map('trim', \explode(',', $watchers))) : [];
+
+        $labels = \getenv('JIRA_ISSUE_LABELS') ?: '';
+        $this->jiraIssueLabels = $labels !== '' ? \array_filter(\array_map('trim', \explode(',', $labels))) : [];
+    }
+}

--- a/src/GitHubGraphQLClient.php
+++ b/src/GitHubGraphQLClient.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira;
+
+use RuntimeException;
+use Softonic\GraphQL\Client as GraphQLClient;
+use Softonic\GraphQL\ClientBuilder;
+
+class GitHubGraphQLClient
+{
+    private GraphQLClient $client;
+
+    public function __construct(
+        private readonly Config $config,
+        ?GraphQLClient $client = null,
+    ) {
+        $this->client = $client ?? ClientBuilder::build($config->githubGraphqlUrl, [
+            'headers' => [
+                'Accept' => 'application/json',
+                'Authorization' => "Bearer {$config->ghSecurityToken}",
+            ],
+        ]);
+    }
+
+    /**
+     * phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+     *
+     * Fetch open vulnerability alerts with pagination.
+     *
+     * @return array<array<string,mixed>>
+     */
+    public function fetchOpenAlerts(): array
+    {
+        // phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+        return $this->fetchAlertsByStates('[OPEN]');
+    }
+
+    /**
+     * phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+     *
+     * Fetch resolved vulnerability alerts with pagination.
+     *
+     * @return array<array<string,mixed>>
+     */
+    public function fetchResolvedAlerts(): array
+    {
+        // phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+        return $this->fetchAlertsByStates('[FIXED, DISMISSED, AUTO_DISMISSED]');
+    }
+
+    /**
+     * Fetch Dependabot security pull requests with pagination.
+     *
+     * @return array<array<string,array<string,string>>>
+     */
+    public function fetchSecurityPullRequests(): array
+    {
+        $repo = $this->config->githubRepository;
+        $author = 'author:app/dependabot author:app/dependabot-preview';
+        $allEdges = [];
+        $cursor = null;
+
+        do {
+            $afterClause = $cursor !== null ? \sprintf(', after: "%s"', $cursor) : '';
+
+            $query = <<<GQL
+{
+  search(query: "type:pr state:open {$author} repo:{$repo} label:security", type: ISSUE, first: 100{$afterClause}) {
+    issueCount
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    edges {
+      node {
+        ... on PullRequest {
+          number
+          title
+          url
+        }
+      }
+    }
+  }
+}
+GQL;
+
+            $data = $this->executeQuery($query, []);
+            $edges = $data['search']['edges'] ?? [];
+            $allEdges = \array_merge($allEdges, $edges);
+
+            $hasNextPage = $data['search']['pageInfo']['hasNextPage'] ?? false;
+            $cursor = $data['search']['pageInfo']['endCursor'] ?? null;
+        } while ($hasNextPage && $cursor !== null);
+
+        return $allEdges;
+    }
+
+    /**
+     * phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+     *
+     * Fetch alerts by state(s) with cursor-based pagination.
+     *
+     * @return array<array<string,mixed>>
+     */
+    private function fetchAlertsByStates(string $statesClause): array
+    {
+        // phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+        $allNodes = [];
+        $cursor = null;
+
+        $resolvedFields = '';
+        if ($statesClause !== '[OPEN]') {
+            $resolvedFields = <<<'GQL'
+                    state
+                    dismissedAt
+                    fixedAt
+                    dismissReason
+GQL;
+        }
+
+        do {
+            $afterClause = $cursor !== null ? \sprintf(', after: "%s"', $cursor) : '';
+
+            $query = <<<GQL
+            query alerts(\$owner: String!, \$repo: String!) {
+              repository(owner: \$owner, name: \$repo) {
+                vulnerabilityAlerts(first: 100, states: {$statesClause}{$afterClause}) {
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
+                  nodes {
+{$resolvedFields}
+                    securityVulnerability {
+                      advisory {
+                        ghsaId
+                        description
+                        identifiers {
+                          type
+                          value
+                        }
+                        references {
+                          url
+                        }
+                        severity
+                        summary
+                      }
+                      firstPatchedVersion {
+                        identifier
+                      }
+                      package {
+                        name
+                        ecosystem
+                      }
+                      severity
+                      updatedAt
+                      vulnerableVersionRange
+                    }
+                    repository {
+                      nameWithOwner
+                    }
+                    vulnerableManifestFilename
+                    vulnerableManifestPath
+                    vulnerableRequirements
+                    number
+                  }
+                }
+              }
+            }
+GQL;
+
+            $variables = [
+                'owner' => $this->config->githubOwner,
+                'repo' => $this->config->githubRepo,
+            ];
+
+            $data = $this->executeQuery($query, $variables);
+
+            $nodes = $data['repository']['vulnerabilityAlerts']['nodes'] ?? [];
+            $allNodes = \array_merge($allNodes, $nodes);
+
+            $hasNextPage = $data['repository']['vulnerabilityAlerts']['pageInfo']['hasNextPage'] ?? false;
+            $cursor = $data['repository']['vulnerabilityAlerts']['pageInfo']['endCursor'] ?? null;
+        } while ($hasNextPage && $cursor !== null);
+
+        return $allNodes;
+    }
+
+    /**
+     * phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+     *
+     * Execute a GraphQL query and return the data.
+     *
+     * @param array<string,mixed> $variables
+     * @return array<string,mixed>
+     */
+    private function executeQuery(string $query, array $variables): array
+    {
+        // phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+        /** @var array<string,mixed> */
+        return RetryableApiCall::execute(function () use ($query, $variables): array {
+            $response = $this->client->query($query, $variables);
+
+            if ($response->hasErrors()) {
+                $messages = \array_map(static function (array $error) {
+                    return $error['message'];
+                }, $response->getErrors());
+
+                throw new RuntimeException(
+                    \sprintf('GraphQL client error: %s. Original query: %s', \implode(', ', $messages), $query),
+                );
+            }
+
+            return $response->getData();
+        });
+    }
+}

--- a/src/JiraTransitionService.php
+++ b/src/JiraTransitionService.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira;
+
+use JiraRestApi\Configuration\ArrayConfiguration;
+use JiraRestApi\Issue\IssueService;
+use JiraRestApi\Issue\Transition;
+use RuntimeException;
+
+class JiraTransitionService
+{
+    private IssueService $issueService;
+
+    public function __construct(
+        private readonly Config $config,
+        ?IssueService $issueService = null,
+    ) {
+        $this->issueService = $issueService ?? new IssueService(new ArrayConfiguration([
+            'jiraHost' => $config->jiraHost,
+            'jiraUser' => $config->jiraUser,
+            'jiraPassword' => $config->jiraToken,
+            'useTokenBasedAuth' => true,
+        ]));
+    }
+
+    /**
+     * Transition an issue to the configured close state with a comment.
+     */
+    public function closeIssue(string $issueKey, string $comment): void
+    {
+        RetryableApiCall::execute(function () use ($issueKey, $comment): void {
+            $transitionId = $this->findTransitionId($issueKey, $this->config->jiraCloseTransition);
+
+            if ($transitionId === null) {
+                throw new RuntimeException(
+                    "Transition '{$this->config->jiraCloseTransition}' not available for issue {$issueKey}."
+                );
+            }
+
+            $transition = new Transition();
+            $transition->setTransitionId($transitionId);
+            $transition->setCommentBody($comment);
+
+            $this->issueService->transition($issueKey, $transition);
+        });
+    }
+
+    /**
+     * Find open Jira issues matching the given labels.
+     *
+     * @param array<string> $labels
+     * @return array<string> Issue keys
+     */
+    public function findIssuesByLabels(array $labels): array
+    {
+        /** @var array<string> */
+        return RetryableApiCall::execute(function () use ($labels): array {
+            $labelConditions = \array_map(
+                static fn (string $label): string => \sprintf('labels = "%s"', $label),
+                $labels
+            );
+
+            $jql = \sprintf(
+                'project = "%s" AND %s AND status != "%s"',
+                $this->config->jiraProject,
+                \implode(' AND ', $labelConditions),
+                $this->config->jiraCloseTransition
+            );
+
+            $result = $this->issueService->search($jql);
+            $keys = [];
+
+            foreach ($result->getIssues() as $issue) {
+                $keys[] = $issue->key;
+            }
+
+            return $keys;
+        });
+    }
+
+    private function findTransitionId(string $issueKey, string $transitionName): ?string
+    {
+        $transitions = $this->issueService->getTransition($issueKey);
+
+        foreach ($transitions as $transition) {
+            if ($transition->name === $transitionName) {
+                return $transition->id;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/PullRequestIssue.php
+++ b/src/PullRequestIssue.php
@@ -6,7 +6,7 @@ namespace GitHubSecurityJira;
 
 use Reload\JiraSecurityIssue;
 
-class PullRequestIssue extends JiraSecurityIssue
+class PullRequestIssue extends JiraSecurityIssue implements SecurityIssueInterface
 {
     /**
      * @var string
@@ -26,14 +26,14 @@ class PullRequestIssue extends JiraSecurityIssue
     /**
      * @param array<string,string> $data
      */
-    public function __construct(array $data)
+    public function __construct(array $data, Config $config)
     {
         $this->package = \preg_filter('/.*Bump (.*) from.*/', '$1', $data['title']) ?? '';
         $this->manifestPath = \preg_filter('/.* in \/(.*)/', '$1', $data['title']) ?? '';
         $this->safeVersion = \preg_filter('/.*to ([^ ]+).*/', '$1', $data['title']) ?? '';
 
-        $githubRepo = \getenv('GITHUB_REPOSITORY') ?: '';
-        $githubUrl = \getenv('GITHUB_SERVER_URL') ?: 'https://github.com';
+        $githubRepo = $config->githubRepository;
+        $githubUrl = $config->githubServerUrl;
 
         $body = <<<EOT
 - Repository: [{$githubRepo}|{$githubUrl}/{$githubRepo}]

--- a/src/RetryableApiCall.php
+++ b/src/RetryableApiCall.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira;
+
+use Throwable;
+
+class RetryableApiCall
+{
+    /**
+     * phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+     *
+     * Execute a callable with exponential backoff retry.
+     *
+     * @return mixed
+     */
+    public static function execute(callable $callable, int $maxRetries = 3, int $initialDelayMs = 1000): mixed
+    {
+        // phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
+        $lastException = null;
+
+        for ($attempt = 0; $attempt <= $maxRetries; $attempt++) {
+            try {
+                return $callable();
+            } catch (Throwable $e) {
+                $lastException = $e;
+
+                if ($attempt < $maxRetries) {
+                    $delayMs = $initialDelayMs * (2 ** $attempt);
+                    \usleep($delayMs * 1000);
+                }
+            }
+        }
+
+        /** @var Throwable $lastException */
+        throw $lastException;
+    }
+}

--- a/src/SecurityAlertIssue.php
+++ b/src/SecurityAlertIssue.php
@@ -6,7 +6,7 @@ namespace GitHubSecurityJira;
 
 use Reload\JiraSecurityIssue;
 
-class SecurityAlertIssue extends JiraSecurityIssue
+class SecurityAlertIssue extends JiraSecurityIssue implements SecurityIssueInterface
 {
     /**
      * @var string
@@ -51,10 +51,16 @@ class SecurityAlertIssue extends JiraSecurityIssue
     /**
      * phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
      *
+     * @var array<string,mixed>
+     */
+    private array $rawData;
+
+    /**
      * @param array<string,mixed> $data
      */
-    public function __construct(array $data)
+    public function __construct(array $data, Config $config)
     {
+        $this->rawData = $data;
         // phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
         $this->package = $data['securityVulnerability']['package']['name'];
         $this->safeVersion = $data['securityVulnerability']['firstPatchedVersion']['identifier'] ?? null;
@@ -77,8 +83,8 @@ class SecurityAlertIssue extends JiraSecurityIssue
 
         $advisory_description = \wordwrap($data['securityVulnerability']['advisory']['description'] ?? '', 100);
         $ecosystem = $data['securityVulnerability']['package']['ecosystem'] ?? '';
-        $githubRepo = \getenv('GITHUB_REPOSITORY') ?: '';
-        $githubUrl = \getenv('GITHUB_SERVER_URL') ?: 'https://github.com';
+        $githubRepo = $config->githubRepository;
+        $githubUrl = $config->githubServerUrl;
         $safeVersion = $this->safeVersion ?? 'no fix';
 
         $body = <<<EOT
@@ -109,13 +115,7 @@ EOT;
         $this->setTitle("{$this->package} ({$safeVersion}) - {$this->severity}");
         $this->setBody($body);
 
-        $labels = \getenv('JIRA_ISSUE_LABELS');
-
-        if (!$labels) {
-            return;
-        }
-
-        foreach (\explode(',', $labels) as $label) {
+        foreach ($config->jiraIssueLabels as $label) {
             $this->setKeyLabel($label);
         }
     }
@@ -127,17 +127,6 @@ EOT;
      */
     public function uniqueId(): string
     {
-        // If there is no safe version we use the GHSA ID as
-        // identifier. If the security alert is later updated with a
-        // known safe version a side effect of this is that a new Jira
-        // issue will be created. We'll consider this a positive side
-        // effect.
-        $identifier = $this->safeVersion ?? $this->id;
-
-        if ($this->manifestPath === '.') {
-            return "{$this->package}:{$identifier}";
-        }
-
-        return str_ireplace(" ", "_", "{$this->package}:{$this->manifestPath}:{$identifier}");
+        return AlertIdentifier::fromAlertData($this->rawData);
     }
 }

--- a/src/SecurityIssueInterface.php
+++ b/src/SecurityIssueInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira;
+
+interface SecurityIssueInterface
+{
+    public function uniqueId(): string;
+
+    public function exists(): ?string;
+
+    public function ensure(): string;
+}

--- a/src/SyncCommand.php
+++ b/src/SyncCommand.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace GitHubSecurityJira;
 
-use RuntimeException;
-use Softonic\GraphQL\Client as GraphQLClient;
-use Softonic\GraphQL\ClientBuilder;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -23,20 +20,6 @@ class SyncCommand extends Command
      * @var string
      */
     protected static $defaultName = 'sync';
-
-    /**
-     * Required options in environment variables.
-     *
-     * @var array<string>
-     */
-    protected $requiredOptions = [
-        'GITHUB_REPOSITORY',
-        'GH_SECURITY_TOKEN',
-        'JIRA_HOST',
-        'JIRA_USER',
-        'JIRA_TOKEN',
-        'JIRA_PROJECT',
-    ];
 
     /**
      * {@inheritDoc}
@@ -64,242 +47,18 @@ class SyncCommand extends Command
 
     /**
      * {@inheritDoc}
-     *
-     * @phpcsSuppress SlevomatCodingStandard.Functions.UnusedParameter.UnusedParameter
      */
-    protected function initialize(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        // Validate config.
-        $this->validateConfig();
-    }
+        $config = new Config();
+        $githubClient = new GitHubGraphQLClient($config);
+        $syncService = new AlertSyncService($config, $githubClient);
+        $dryRun = (bool) $input->getOption('dry-run');
 
-    /**
-     * {@inheritDoc}
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
-    {
+        $alertIds = $syncService->syncOpenAlerts($output, $dryRun);
+        $syncService->syncPullRequests($output, $dryRun, $alertIds);
+        $syncService->closeResolvedAlerts($output, $dryRun);
 
-        // Fetch alert data from GitHub.
-        $alerts = $this->fetchAlertData();
-
-        if (!\is_array($alerts)) {
-            $this->log($output, 'No alerts found.');
-        }
-
-        $alertsFound = [];
-
-        // Go through each alert and create a Jira issue if one does not exist.
-        foreach ($alerts as $alert) {
-            $issue = new SecurityAlertIssue($alert);
-
-            $existingKey = $issue->exists();
-
-            if (!\is_null($existingKey)) {
-                $this->log($output, "Existing issue {$existingKey} covers {$issue->uniqueId()}.");
-            } elseif (!$input->getOption('dry-run')) {
-                $key = $issue->ensure();
-                $this->log($output, "Created issue {$key} for {$issue->uniqueId()}.");
-            } else {
-                $this->log($output, "Would have created an issue for {$issue->uniqueId()} if not a dry run.");
-            }
-
-            $alertsFound[] = $issue->uniqueId();
-        }
-
-        $pull_requests = $this->fetchPullRequestData();
-
-        foreach ($pull_requests as $pull_request) {
-            $issue = new PullRequestIssue($pull_request['node']);
-
-            if (\in_array($issue->uniqueId(), $alertsFound)) {
-                continue;
-            }
-
-            $existingKey = $issue->exists();
-
-            if (!\is_null($existingKey)) {
-                $this->log($output, "Existing issue {$existingKey} covers {$issue->uniqueId()}.");
-            } elseif (!$input->getOption('dry-run')) {
-                $key = $issue->ensure();
-                $this->log($output, "Created issue {$key} for {$issue->uniqueId()}.");
-            } else {
-                $this->log($output, "Would have created an issue for {$issue->uniqueId()} if not a dry run.");
-            }
-        }
-
-        return 0;
-    }
-
-    /**
-     * phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
-     *
-     * Fetch alert data from GitHub.
-     *
-     * @return array<string,mixed>
-     */
-    protected function fetchAlertData(): array
-    {
-        // phpcs:enable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
-        $query = <<<'GQL'
-            query alerts($owner: String!, $repo: String!) {
-              repository(owner: $owner, name: $repo) {
-                vulnerabilityAlerts(first: 100, states: OPEN) {
-                  nodes {
-                    securityVulnerability {
-                      advisory {
-                        ghsaId
-                        description
-                        identifiers {
-                          type
-                          value
-                        }
-                        references {
-                          url
-                        }
-                        severity
-                        summary
-                      }
-                      firstPatchedVersion {
-                        identifier
-                      }
-                      package {
-                        name
-                        ecosystem
-                      }
-                      severity
-                      updatedAt
-                      vulnerableVersionRange
-                    }
-                    repository {
-                      nameWithOwner
-                    }
-                    vulnerableManifestFilename
-                    vulnerableManifestPath
-                    vulnerableRequirements
-                    number
-                  }
-                }
-              }
-            }
-GQL;
-
-        $repo = \explode('/', \getenv('GITHUB_REPOSITORY') ?: '');
-        $variables = [
-            'owner' => $repo[0],
-            'repo' => $repo[1],
-        ];
-
-        $response = $this->getGHClient()->query($query, $variables);
-
-        if ($response->hasErrors()) {
-            $messages = \array_map(static function (array $error) {
-                return $error['message'];
-            }, $response->getErrors());
-
-            throw new RuntimeException(
-                \sprintf('GraphQL client error: %s. Original query: %s', \implode(', ', $messages), $query),
-            );
-        }
-
-        // Drill down to the response data we want, if there.
-        $alert_data = $response->getData();
-
-        return $alert_data['repository']['vulnerabilityAlerts']['nodes'] ?? [];
-    }
-
-    /**
-     * Fetch Dependabot pull request data from GitHub.
-     *
-     * @return array<array<string,array<string,string>>>
-     */
-    protected function fetchPullRequestData(): array
-    {
-        $repo = \getenv('GITHUB_REPOSITORY');
-        $author = 'author:app/dependabot author:app/dependabot-preview';
-
-        $query = <<<GQL
-{
-  search(query: "type:pr state:open {$author} repo:{$repo} label:security", type: ISSUE, first: 100) {
-    issueCount
-    pageInfo {
-      endCursor
-      startCursor
-    }
-    edges {
-      node {
-        ... on PullRequest {
-          number
-          title
-          url
-        }
-      }
-    }
-  }
-}
-GQL;
-
-        $variables = [];
-
-        $response = $this->getGHClient()->query($query, $variables);
-
-        if ($response->hasErrors()) {
-            $messages = \array_map(static function (array $error) {
-                return $error['message'];
-            }, $response->getErrors());
-
-            throw new RuntimeException(
-                \sprintf('GraphQL client error: %s. Original query: %s', \implode(', ', $messages), $query),
-            );
-        }
-
-        // Drill down to the response data we want, if there.
-        $pr_data = $response->getData();
-
-        return $pr_data['search']['edges'] ?? [];
-    }
-
-    /**
-     * Create the GraphQL client with supplied Bearer token.
-     */
-    protected function getGHClient(): GraphQLClient
-    {
-        $access_token = \getenv('GH_SECURITY_TOKEN');
-        $graphql_url = \getenv('GITHUB_GRAPHQL_URL') ?: 'https://api.github.com/graphql';
-        return ClientBuilder::build($graphql_url, [
-            'headers' => [
-                'Accept' => 'application/json',
-                'Authorization' => "Bearer {$access_token}",
-            ],
-        ]);
-    }
-
-    /**
-     * Validate the required options.
-     */
-    protected function validateConfig(): void
-    {
-        foreach ($this->requiredOptions as $option) {
-            $var = \getenv($option);
-
-            if (!\is_string($var)) {
-                throw new RuntimeException("Required env variable '{$option}' not set or empty.");
-            }
-
-            if (($option === 'GITHUB_REPOSITORY') && (\count(\explode('/', $var)) < 2)) {
-                throw new RuntimeException('GitHub repository invalid: ' . \getenv('GITHUB_REPOSITORY'));
-            }
-        }
-    }
-
-    protected function log(OutputInterface $output, string $message): void
-    {
-        if ($output->getVerbosity() < OutputInterface::VERBOSITY_VERBOSE) {
-            return;
-        }
-
-        $timestamp = \gmdate(\DATE_ATOM);
-        $jira_project = \getenv('JIRA_PROJECT');
-
-        $output->writeln("{$timestamp} - {$jira_project} - {$message}");
+        return Command::SUCCESS;
     }
 }

--- a/tests/Fixtures/alert-response.php
+++ b/tests/Fixtures/alert-response.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'securityVulnerability' => [
+        'advisory' => [
+            'ghsaId' => 'GHSA-1234-5678-abcd',
+            'description' => 'A prototype pollution vulnerability in lodash allows attackers to manipulate object prototypes.',
+            'identifiers' => [
+                ['type' => 'CVE', 'value' => 'CVE-2021-12345'],
+                ['type' => 'GHSA', 'value' => 'GHSA-1234-5678-abcd'],
+            ],
+            'references' => [
+                ['url' => 'https://nvd.nist.gov/vuln/detail/CVE-2021-12345'],
+                ['url' => 'https://github.com/advisories/GHSA-1234-5678-abcd'],
+            ],
+            'severity' => 'HIGH',
+            'summary' => 'Prototype Pollution in lodash',
+        ],
+        'firstPatchedVersion' => [
+            'identifier' => '4.17.21',
+        ],
+        'package' => [
+            'name' => 'lodash',
+            'ecosystem' => 'NPM',
+        ],
+        'severity' => 'HIGH',
+        'updatedAt' => '2024-01-15T10:30:00Z',
+        'vulnerableVersionRange' => '< 4.17.21',
+    ],
+    'repository' => [
+        'nameWithOwner' => 'reload/github-security-jira',
+    ],
+    'vulnerableManifestFilename' => 'package-lock.json',
+    'vulnerableManifestPath' => 'package-lock.json',
+    'vulnerableRequirements' => '= 4.17.15',
+    'number' => 42,
+];

--- a/tests/Fixtures/pr-response.php
+++ b/tests/Fixtures/pr-response.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'node' => [
+        'number' => '101',
+        'title' => 'Bump lodash from 4.17.15 to 4.17.21 in /frontend',
+        'url' => 'https://github.com/reload/github-security-jira/pull/101',
+    ],
+];

--- a/tests/Integration/CloseResolvedAlertsTest.php
+++ b/tests/Integration/CloseResolvedAlertsTest.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira\Tests\Integration;
+
+use GitHubSecurityJira\AlertSyncService;
+use GitHubSecurityJira\Config;
+use GitHubSecurityJira\GitHubGraphQLClient;
+use GitHubSecurityJira\JiraTransitionService;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Softonic\GraphQL\Client as GraphQLClient;
+use Softonic\GraphQL\Response;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CloseResolvedAlertsTest extends TestCase
+{
+    /**
+     * @var array<string,string|false>
+     */
+    private array $originalEnv = [];
+
+    protected function setUp(): void
+    {
+        $vars = [
+            'GITHUB_REPOSITORY', 'GH_SECURITY_TOKEN', 'JIRA_HOST',
+            'JIRA_USER', 'JIRA_TOKEN', 'JIRA_PROJECT', 'JIRA_CLOSE_TRANSITION',
+            'JIRA_ISSUE_LABELS', 'JIRA_WATCHERS',
+        ];
+        foreach ($vars as $var) {
+            $this->originalEnv[$var] = \getenv($var);
+        }
+
+        \putenv('GITHUB_REPOSITORY=reload/github-security-jira');
+        \putenv('GH_SECURITY_TOKEN=ghp_test');
+        \putenv('JIRA_HOST=https://test.atlassian.net');
+        \putenv('JIRA_USER=test@example.com');
+        \putenv('JIRA_TOKEN=token');
+        \putenv('JIRA_PROJECT=TEST');
+        \putenv('JIRA_CLOSE_TRANSITION=Done');
+        \putenv('JIRA_ISSUE_LABELS');
+        \putenv('JIRA_WATCHERS');
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalEnv as $var => $value) {
+            if ($value === false) {
+                \putenv($var);
+            } else {
+                \putenv("{$var}={$value}");
+            }
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function makeResolvedAlert(string $state = 'FIXED'): array
+    {
+        return [
+            'state' => $state,
+            'fixedAt' => '2024-01-15T10:30:00Z',
+            'dismissedAt' => null,
+            'dismissReason' => null,
+            'number' => 42,
+            'securityVulnerability' => [
+                'advisory' => [
+                    'ghsaId' => 'GHSA-1234-5678-abcd',
+                    'summary' => 'Prototype Pollution in lodash',
+                ],
+                'firstPatchedVersion' => ['identifier' => '4.17.21'],
+                'package' => ['name' => 'lodash', 'ecosystem' => 'NPM'],
+                'severity' => 'HIGH',
+                'vulnerableVersionRange' => '< 4.17.21',
+            ],
+            'vulnerableManifestFilename' => 'package-lock.json',
+            'vulnerableManifestPath' => '/package-lock.json',
+            'vulnerableRequirements' => '= 4.17.15',
+        ];
+    }
+
+    public function testDryRunLogsWouldClose(): void
+    {
+        $mockResponse = $this->createMock(Response::class);
+        $mockResponse->method('hasErrors')->willReturn(false);
+        $mockResponse->method('getData')->willReturn([
+            'repository' => [
+                'vulnerabilityAlerts' => [
+                    'nodes' => [$this->makeResolvedAlert()],
+                ],
+            ],
+        ]);
+
+        $mockGraphQL = $this->createMock(GraphQLClient::class);
+        $mockGraphQL->method('query')->willReturn($mockResponse);
+
+        $mockTransition = $this->createMock(JiraTransitionService::class);
+        $mockTransition->method('findIssuesByLabels')->willReturn(['TEST-100']);
+
+        $config = new Config();
+        $githubClient = new GitHubGraphQLClient($config, $mockGraphQL);
+        $syncService = new AlertSyncService($config, $githubClient, $mockTransition);
+
+        $output = new BufferedOutput();
+        $output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
+
+        $syncService->closeResolvedAlerts($output, true);
+
+        $this->assertStringContainsString('Would close TEST-100 (alert FIXED)', $output->fetch());
+    }
+
+    public function testCloseIssueCalledWhenNotDryRun(): void
+    {
+        $mockResponse = $this->createMock(Response::class);
+        $mockResponse->method('hasErrors')->willReturn(false);
+        $mockResponse->method('getData')->willReturn([
+            'repository' => [
+                'vulnerabilityAlerts' => [
+                    'nodes' => [$this->makeResolvedAlert()],
+                ],
+            ],
+        ]);
+
+        $mockGraphQL = $this->createMock(GraphQLClient::class);
+        $mockGraphQL->method('query')->willReturn($mockResponse);
+
+        $mockTransition = $this->createMock(JiraTransitionService::class);
+        $mockTransition->method('findIssuesByLabels')->willReturn(['TEST-100']);
+        $mockTransition->expects($this->once())
+            ->method('closeIssue')
+            ->with('TEST-100', $this->stringContains('FIXED'));
+
+        $config = new Config();
+        $githubClient = new GitHubGraphQLClient($config, $mockGraphQL);
+        $syncService = new AlertSyncService($config, $githubClient, $mockTransition);
+
+        $output = new BufferedOutput();
+        $output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
+
+        $syncService->closeResolvedAlerts($output, false);
+    }
+
+    public function testTransitionFailureDoesNotStopProcessing(): void
+    {
+        $alerts = [
+            $this->makeResolvedAlert(),
+            $this->makeResolvedAlert('DISMISSED'),
+        ];
+        $alerts[1]['securityVulnerability']['package']['name'] = 'axios';
+        $alerts[1]['securityVulnerability']['firstPatchedVersion']['identifier'] = '0.21.1';
+        $alerts[1]['dismissedAt'] = '2024-02-01T00:00:00Z';
+        $alerts[1]['dismissReason'] = 'not_used';
+
+        $mockResponse = $this->createMock(Response::class);
+        $mockResponse->method('hasErrors')->willReturn(false);
+        $mockResponse->method('getData')->willReturn([
+            'repository' => [
+                'vulnerabilityAlerts' => [
+                    'nodes' => $alerts,
+                ],
+            ],
+        ]);
+
+        $mockGraphQL = $this->createMock(GraphQLClient::class);
+        $mockGraphQL->method('query')->willReturn($mockResponse);
+
+        $mockTransition = $this->createMock(JiraTransitionService::class);
+        $mockTransition->method('findIssuesByLabels')
+            ->willReturnOnConsecutiveCalls(['TEST-100'], ['TEST-200']);
+        $mockTransition->method('closeIssue')
+            ->willReturnCallback(function (string $key): void {
+                if ($key === 'TEST-100') {
+                    throw new RuntimeException('Transition failed');
+                }
+            });
+
+        $config = new Config();
+        $githubClient = new GitHubGraphQLClient($config, $mockGraphQL);
+        $syncService = new AlertSyncService($config, $githubClient, $mockTransition);
+
+        $output = new BufferedOutput();
+        $output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
+
+        $syncService->closeResolvedAlerts($output, false);
+
+        $outputText = $output->fetch();
+        $this->assertStringContainsString('Failed to close TEST-100', $outputText);
+        $this->assertStringContainsString('Closed TEST-200', $outputText);
+    }
+
+    public function testNoResolvedAlertsLogsMessage(): void
+    {
+        $mockResponse = $this->createMock(Response::class);
+        $mockResponse->method('hasErrors')->willReturn(false);
+        $mockResponse->method('getData')->willReturn([
+            'repository' => [
+                'vulnerabilityAlerts' => [
+                    'nodes' => [],
+                ],
+            ],
+        ]);
+
+        $mockGraphQL = $this->createMock(GraphQLClient::class);
+        $mockGraphQL->method('query')->willReturn($mockResponse);
+
+        $config = new Config();
+        $githubClient = new GitHubGraphQLClient($config, $mockGraphQL);
+        $syncService = new AlertSyncService($config, $githubClient);
+
+        $output = new BufferedOutput();
+        $output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
+
+        $syncService->closeResolvedAlerts($output, false);
+
+        $this->assertStringContainsString('No resolved alerts found', $output->fetch());
+    }
+}

--- a/tests/Integration/SyncCommandTest.php
+++ b/tests/Integration/SyncCommandTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira\Tests\Integration;
+
+use GitHubSecurityJira\SyncCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class SyncCommandTest extends TestCase
+{
+    /**
+     * @var array<string,string|false>
+     */
+    private array $originalEnv = [];
+
+    protected function setUp(): void
+    {
+        $vars = [
+            'GITHUB_REPOSITORY', 'GH_SECURITY_TOKEN', 'JIRA_HOST',
+            'JIRA_USER', 'JIRA_TOKEN', 'JIRA_PROJECT',
+            'JIRA_ISSUE_LABELS', 'JIRA_WATCHERS',
+        ];
+        foreach ($vars as $var) {
+            $this->originalEnv[$var] = \getenv($var);
+        }
+
+        \putenv('GITHUB_REPOSITORY=reload/github-security-jira');
+        \putenv('GH_SECURITY_TOKEN=ghp_test');
+        \putenv('JIRA_HOST=https://test.atlassian.net');
+        \putenv('JIRA_USER=test@example.com');
+        \putenv('JIRA_TOKEN=token');
+        \putenv('JIRA_PROJECT=TEST');
+        \putenv('JIRA_ISSUE_LABELS');
+        \putenv('JIRA_WATCHERS');
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalEnv as $var => $value) {
+            if ($value === false) {
+                \putenv($var);
+            } else {
+                \putenv("{$var}={$value}");
+            }
+        }
+    }
+
+    public function testCommandIsRegistered(): void
+    {
+        $application = new Application('ghsec-jira');
+        $command = new SyncCommand();
+        $application->add($command);
+
+        $this->assertTrue($application->has('sync'));
+    }
+
+    public function testCommandHasDryRunOption(): void
+    {
+        $command = new SyncCommand();
+        $definition = $command->getDefinition();
+
+        $this->assertTrue($definition->hasOption('dry-run'));
+        $this->assertFalse($definition->getOption('dry-run')->acceptValue());
+    }
+}

--- a/tests/Unit/AlertIdentifierTest.php
+++ b/tests/Unit/AlertIdentifierTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira\Tests\Unit;
+
+use GitHubSecurityJira\AlertIdentifier;
+use PHPUnit\Framework\TestCase;
+
+class AlertIdentifierTest extends TestCase
+{
+    public function testWithSafeVersionRootManifest(): void
+    {
+        $data = require __DIR__ . '/../Fixtures/alert-response.php';
+        // Root manifest: pathinfo dirname = "."
+        $data['vulnerableManifestPath'] = 'package-lock.json';
+
+        $this->assertSame('lodash:4.17.21', AlertIdentifier::fromAlertData($data));
+    }
+
+    public function testWithSafeVersionSubdirectory(): void
+    {
+        $data = require __DIR__ . '/../Fixtures/alert-response.php';
+        $data['vulnerableManifestPath'] = 'frontend/package-lock.json';
+
+        $this->assertSame('lodash:frontend:4.17.21', AlertIdentifier::fromAlertData($data));
+    }
+
+    public function testWithoutSafeVersionUsesGhsaId(): void
+    {
+        $data = require __DIR__ . '/../Fixtures/alert-response.php';
+        unset($data['securityVulnerability']['firstPatchedVersion']);
+        $data['vulnerableManifestPath'] = 'package-lock.json';
+
+        $this->assertSame('lodash:GHSA-1234-5678-abcd', AlertIdentifier::fromAlertData($data));
+    }
+
+    public function testSpacesReplacedWithUnderscores(): void
+    {
+        $data = require __DIR__ . '/../Fixtures/alert-response.php';
+        $data['vulnerableManifestPath'] = 'my dir/package-lock.json';
+
+        $this->assertSame('lodash:my_dir:4.17.21', AlertIdentifier::fromAlertData($data));
+    }
+
+    public function testMatchesSecurityAlertIssueUniqueId(): void
+    {
+        // Verify the static method produces the same result as the instance method
+        // would for the same data. Both should use the same algorithm.
+        $data = require __DIR__ . '/../Fixtures/alert-response.php';
+
+        $fromStatic = AlertIdentifier::fromAlertData($data);
+
+        // Based on fixture: root manifest (/package-lock.json -> "."), has safeVersion 4.17.21
+        $this->assertSame('lodash:4.17.21', $fromStatic);
+    }
+}

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira\Tests\Unit;
+
+use GitHubSecurityJira\Config;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ConfigTest extends TestCase
+{
+    /**
+     * @var array<string,string|false>
+     */
+    private array $originalEnv = [];
+
+    /**
+     * @var array<string>
+     */
+    private array $envVarsToRestore = [
+        'GITHUB_REPOSITORY',
+        'GH_SECURITY_TOKEN',
+        'JIRA_HOST',
+        'JIRA_USER',
+        'JIRA_TOKEN',
+        'JIRA_PROJECT',
+        'GITHUB_GRAPHQL_URL',
+        'GITHUB_SERVER_URL',
+        'JIRA_ISSUE_TYPE',
+        'JIRA_RESTRICTED_COMMENT_ROLE',
+        'JIRA_CLOSE_TRANSITION',
+        'JIRA_WATCHERS',
+        'JIRA_ISSUE_LABELS',
+    ];
+
+    protected function setUp(): void
+    {
+        foreach ($this->envVarsToRestore as $var) {
+            $this->originalEnv[$var] = \getenv($var);
+        }
+
+        $this->setRequiredEnv();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalEnv as $var => $value) {
+            if ($value === false) {
+                \putenv($var);
+            } else {
+                \putenv("{$var}={$value}");
+            }
+        }
+    }
+
+    private function setRequiredEnv(): void
+    {
+        \putenv('GITHUB_REPOSITORY=reload/github-security-jira');
+        \putenv('GH_SECURITY_TOKEN=ghp_test123');
+        \putenv('JIRA_HOST=https://test.atlassian.net');
+        \putenv('JIRA_USER=test@example.com');
+        \putenv('JIRA_TOKEN=jira_test_token');
+        \putenv('JIRA_PROJECT=TEST');
+    }
+
+    public function testRequiredVarsPresent(): void
+    {
+        $config = new Config();
+
+        $this->assertSame('reload/github-security-jira', $config->githubRepository);
+        $this->assertSame('reload', $config->githubOwner);
+        $this->assertSame('github-security-jira', $config->githubRepo);
+        $this->assertSame('ghp_test123', $config->ghSecurityToken);
+        $this->assertSame('https://test.atlassian.net', $config->jiraHost);
+        $this->assertSame('test@example.com', $config->jiraUser);
+        $this->assertSame('jira_test_token', $config->jiraToken);
+        $this->assertSame('TEST', $config->jiraProject);
+    }
+
+    public function testMissingRequiredVarThrows(): void
+    {
+        \putenv('JIRA_PROJECT');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Required env variable 'JIRA_PROJECT' not set or empty.");
+
+        new Config();
+    }
+
+    public function testInvalidRepositoryFormatThrows(): void
+    {
+        \putenv('GITHUB_REPOSITORY=invalid-no-slash');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('GitHub repository invalid');
+
+        new Config();
+    }
+
+    public function testDefaults(): void
+    {
+        \putenv('GITHUB_GRAPHQL_URL');
+        \putenv('GITHUB_SERVER_URL');
+        \putenv('JIRA_ISSUE_TYPE');
+        \putenv('JIRA_RESTRICTED_COMMENT_ROLE');
+        \putenv('JIRA_CLOSE_TRANSITION');
+        \putenv('JIRA_WATCHERS');
+        \putenv('JIRA_ISSUE_LABELS');
+
+        $config = new Config();
+
+        $this->assertSame('https://api.github.com/graphql', $config->githubGraphqlUrl);
+        $this->assertSame('https://github.com', $config->githubServerUrl);
+        $this->assertSame('Bug', $config->jiraIssueType);
+        $this->assertSame('Developers', $config->jiraRestrictedCommentRole);
+        $this->assertSame('Done', $config->jiraCloseTransition);
+        $this->assertSame([], $config->jiraWatchers);
+        $this->assertSame([], $config->jiraIssueLabels);
+    }
+
+    public function testLabelParsing(): void
+    {
+        \putenv('JIRA_ISSUE_LABELS=security,dependabot,critical');
+
+        $config = new Config();
+
+        $this->assertSame(['security', 'dependabot', 'critical'], $config->jiraIssueLabels);
+    }
+
+    public function testWatcherParsing(): void
+    {
+        \putenv('JIRA_WATCHERS=user1@test.com,user2@test.com');
+
+        $config = new Config();
+
+        $this->assertSame(['user1@test.com', 'user2@test.com'], $config->jiraWatchers);
+    }
+
+    public function testEmptyLabelsReturnsEmptyArray(): void
+    {
+        \putenv('JIRA_ISSUE_LABELS=');
+
+        $config = new Config();
+
+        $this->assertSame([], $config->jiraIssueLabels);
+    }
+
+    public function testCustomCloseTransition(): void
+    {
+        \putenv('JIRA_CLOSE_TRANSITION=Resolved');
+
+        $config = new Config();
+
+        $this->assertSame('Resolved', $config->jiraCloseTransition);
+    }
+}

--- a/tests/Unit/GitHubGraphQLClientTest.php
+++ b/tests/Unit/GitHubGraphQLClientTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira\Tests\Unit;
+
+use GitHubSecurityJira\Config;
+use GitHubSecurityJira\GitHubGraphQLClient;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Softonic\GraphQL\Client as GraphQLClient;
+use Softonic\GraphQL\Response;
+
+class GitHubGraphQLClientTest extends TestCase
+{
+    /**
+     * @var array<string,string|false>
+     */
+    private array $originalEnv = [];
+
+    protected function setUp(): void
+    {
+        $vars = [
+            'GITHUB_REPOSITORY', 'GH_SECURITY_TOKEN', 'JIRA_HOST',
+            'JIRA_USER', 'JIRA_TOKEN', 'JIRA_PROJECT',
+        ];
+        foreach ($vars as $var) {
+            $this->originalEnv[$var] = \getenv($var);
+        }
+
+        \putenv('GITHUB_REPOSITORY=reload/github-security-jira');
+        \putenv('GH_SECURITY_TOKEN=ghp_test');
+        \putenv('JIRA_HOST=https://test.atlassian.net');
+        \putenv('JIRA_USER=test@example.com');
+        \putenv('JIRA_TOKEN=token');
+        \putenv('JIRA_PROJECT=TEST');
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalEnv as $var => $value) {
+            if ($value === false) {
+                \putenv($var);
+            } else {
+                \putenv("{$var}={$value}");
+            }
+        }
+    }
+
+    public function testFetchOpenAlertsReturnsNodes(): void
+    {
+        $alertNode = require __DIR__ . '/../Fixtures/alert-response.php';
+        $mockResponse = $this->createMock(Response::class);
+        $mockResponse->method('hasErrors')->willReturn(false);
+        $mockResponse->method('getData')->willReturn([
+            'repository' => [
+                'vulnerabilityAlerts' => [
+                    'nodes' => [$alertNode],
+                ],
+            ],
+        ]);
+
+        $mockClient = $this->createMock(GraphQLClient::class);
+        $mockClient->method('query')->willReturn($mockResponse);
+
+        $config = new Config();
+        $client = new GitHubGraphQLClient($config, $mockClient);
+
+        $alerts = $client->fetchOpenAlerts();
+        $this->assertCount(1, $alerts);
+        $this->assertSame('lodash', $alerts[0]['securityVulnerability']['package']['name']);
+    }
+
+    public function testFetchOpenAlertsReturnsEmptyWhenNoNodes(): void
+    {
+        $mockResponse = $this->createMock(Response::class);
+        $mockResponse->method('hasErrors')->willReturn(false);
+        $mockResponse->method('getData')->willReturn([
+            'repository' => [
+                'vulnerabilityAlerts' => [
+                    'nodes' => [],
+                ],
+            ],
+        ]);
+
+        $mockClient = $this->createMock(GraphQLClient::class);
+        $mockClient->method('query')->willReturn($mockResponse);
+
+        $config = new Config();
+        $client = new GitHubGraphQLClient($config, $mockClient);
+
+        $this->assertSame([], $client->fetchOpenAlerts());
+    }
+
+    public function testFetchResolvedAlertsReturnsNodes(): void
+    {
+        $mockResponse = $this->createMock(Response::class);
+        $mockResponse->method('hasErrors')->willReturn(false);
+        $mockResponse->method('getData')->willReturn([
+            'repository' => [
+                'vulnerabilityAlerts' => [
+                    'nodes' => [
+                        [
+                            'state' => 'FIXED',
+                            'fixedAt' => '2024-01-15T10:30:00Z',
+                            'dismissedAt' => null,
+                            'dismissReason' => null,
+                            'number' => 42,
+                            'securityVulnerability' => [
+                                'advisory' => [
+                                    'ghsaId' => 'GHSA-1234',
+                                    'summary' => 'Test advisory',
+                                ],
+                                'firstPatchedVersion' => ['identifier' => '1.0.1'],
+                                'package' => ['name' => 'test-pkg', 'ecosystem' => 'NPM'],
+                                'severity' => 'HIGH',
+                                'vulnerableVersionRange' => '< 1.0.1',
+                            ],
+                            'vulnerableManifestFilename' => 'package-lock.json',
+                            'vulnerableManifestPath' => '/package-lock.json',
+                            'vulnerableRequirements' => '= 1.0.0',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $mockClient = $this->createMock(GraphQLClient::class);
+        $mockClient->method('query')->willReturn($mockResponse);
+
+        $config = new Config();
+        $client = new GitHubGraphQLClient($config, $mockClient);
+
+        $alerts = $client->fetchResolvedAlerts();
+        $this->assertCount(1, $alerts);
+        $this->assertSame('FIXED', $alerts[0]['state']);
+    }
+
+    public function testFetchSecurityPullRequestsReturnsEdges(): void
+    {
+        $prEdge = require __DIR__ . '/../Fixtures/pr-response.php';
+        $mockResponse = $this->createMock(Response::class);
+        $mockResponse->method('hasErrors')->willReturn(false);
+        $mockResponse->method('getData')->willReturn([
+            'search' => [
+                'edges' => [$prEdge],
+            ],
+        ]);
+
+        $mockClient = $this->createMock(GraphQLClient::class);
+        $mockClient->method('query')->willReturn($mockResponse);
+
+        $config = new Config();
+        $client = new GitHubGraphQLClient($config, $mockClient);
+
+        $prs = $client->fetchSecurityPullRequests();
+        $this->assertCount(1, $prs);
+    }
+
+    public function testGraphQLErrorThrowsException(): void
+    {
+        $mockResponse = $this->createMock(Response::class);
+        $mockResponse->method('hasErrors')->willReturn(true);
+        $mockResponse->method('getErrors')->willReturn([
+            ['message' => 'Some GraphQL error'],
+        ]);
+
+        $mockClient = $this->createMock(GraphQLClient::class);
+        $mockClient->method('query')->willReturn($mockResponse);
+
+        $config = new Config();
+        $client = new GitHubGraphQLClient($config, $mockClient);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('GraphQL client error: Some GraphQL error');
+
+        $client->fetchOpenAlerts();
+    }
+}

--- a/tests/Unit/JiraTransitionServiceTest.php
+++ b/tests/Unit/JiraTransitionServiceTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira\Tests\Unit;
+
+use ArrayObject;
+use GitHubSecurityJira\Config;
+use GitHubSecurityJira\JiraTransitionService;
+use JiraRestApi\Issue\Issue;
+use JiraRestApi\Issue\IssueSearchResult;
+use JiraRestApi\Issue\IssueService;
+use JiraRestApi\Issue\Transition;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class JiraTransitionServiceTest extends TestCase
+{
+    /**
+     * @var array<string,string|false>
+     */
+    private array $originalEnv = [];
+
+    protected function setUp(): void
+    {
+        $vars = [
+            'GITHUB_REPOSITORY', 'GH_SECURITY_TOKEN', 'JIRA_HOST',
+            'JIRA_USER', 'JIRA_TOKEN', 'JIRA_PROJECT', 'JIRA_CLOSE_TRANSITION',
+        ];
+        foreach ($vars as $var) {
+            $this->originalEnv[$var] = \getenv($var);
+        }
+
+        \putenv('GITHUB_REPOSITORY=reload/github-security-jira');
+        \putenv('GH_SECURITY_TOKEN=ghp_test');
+        \putenv('JIRA_HOST=https://test.atlassian.net');
+        \putenv('JIRA_USER=test@example.com');
+        \putenv('JIRA_TOKEN=token');
+        \putenv('JIRA_PROJECT=TEST');
+        \putenv('JIRA_CLOSE_TRANSITION=Done');
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalEnv as $var => $value) {
+            if ($value === false) {
+                \putenv($var);
+            } else {
+                \putenv("{$var}={$value}");
+            }
+        }
+    }
+
+    public function testCloseIssueCallsTransition(): void
+    {
+        $transition = new Transition();
+        $transition->id = '31';
+        $transition->name = 'Done';
+
+        $mockIssueService = $this->createMock(IssueService::class);
+        $mockIssueService->method('getTransition')
+            ->with('TEST-123')
+            ->willReturn(new ArrayObject([$transition]));
+        $mockIssueService->expects($this->once())
+            ->method('transition')
+            ->with('TEST-123', $this->isInstanceOf(Transition::class));
+
+        $config = new Config();
+        $service = new JiraTransitionService($config, $mockIssueService);
+        $service->closeIssue('TEST-123', 'Alert resolved: *FIXED*');
+    }
+
+    public function testCloseIssueThrowsWhenTransitionNotFound(): void
+    {
+        $mockIssueService = $this->createMock(IssueService::class);
+        $mockIssueService->method('getTransition')
+            ->willReturn(new ArrayObject([]));
+
+        $config = new Config();
+        $service = new JiraTransitionService($config, $mockIssueService);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Transition 'Done' not available");
+
+        $service->closeIssue('TEST-123', 'Alert resolved');
+    }
+
+    public function testFindIssuesByLabelsBuildsCorrectJql(): void
+    {
+        $issue = new Issue();
+        $issue->key = 'TEST-456';
+
+        $searchResult = new IssueSearchResult();
+        $searchResult->issues = [$issue];
+
+        $mockIssueService = $this->createMock(IssueService::class);
+        $mockIssueService->expects($this->once())
+            ->method('search')
+            ->with($this->callback(function (string $jql): bool {
+                return \str_contains($jql, 'project = "TEST"')
+                    && \str_contains($jql, 'labels = "reload/github-security-jira"')
+                    && \str_contains($jql, 'labels = "lodash:4.17.21"')
+                    && \str_contains($jql, 'status != "Done"');
+            }))
+            ->willReturn($searchResult);
+
+        $config = new Config();
+        $service = new JiraTransitionService($config, $mockIssueService);
+        $keys = $service->findIssuesByLabels(['reload/github-security-jira', 'lodash:4.17.21']);
+
+        $this->assertSame(['TEST-456'], $keys);
+    }
+
+    public function testFindIssuesByLabelsReturnsEmptyWhenNoMatches(): void
+    {
+        $searchResult = new IssueSearchResult();
+        $searchResult->issues = [];
+
+        $mockIssueService = $this->createMock(IssueService::class);
+        $mockIssueService->method('search')->willReturn($searchResult);
+
+        $config = new Config();
+        $service = new JiraTransitionService($config, $mockIssueService);
+
+        $this->assertSame([], $service->findIssuesByLabels(['repo', 'id']));
+    }
+}

--- a/tests/Unit/PaginationTest.php
+++ b/tests/Unit/PaginationTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira\Tests\Unit;
+
+use GitHubSecurityJira\Config;
+use GitHubSecurityJira\GitHubGraphQLClient;
+use PHPUnit\Framework\TestCase;
+use Softonic\GraphQL\Client as GraphQLClient;
+use Softonic\GraphQL\Response;
+
+class PaginationTest extends TestCase
+{
+    /**
+     * @var array<string,string|false>
+     */
+    private array $originalEnv = [];
+
+    protected function setUp(): void
+    {
+        $vars = [
+            'GITHUB_REPOSITORY', 'GH_SECURITY_TOKEN', 'JIRA_HOST',
+            'JIRA_USER', 'JIRA_TOKEN', 'JIRA_PROJECT',
+        ];
+        foreach ($vars as $var) {
+            $this->originalEnv[$var] = \getenv($var);
+        }
+
+        \putenv('GITHUB_REPOSITORY=reload/github-security-jira');
+        \putenv('GH_SECURITY_TOKEN=ghp_test');
+        \putenv('JIRA_HOST=https://test.atlassian.net');
+        \putenv('JIRA_USER=test@example.com');
+        \putenv('JIRA_TOKEN=token');
+        \putenv('JIRA_PROJECT=TEST');
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalEnv as $var => $value) {
+            if ($value === false) {
+                \putenv($var);
+            } else {
+                \putenv("{$var}={$value}");
+            }
+        }
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     */
+    private function mockResponse(array $data): Response
+    {
+        $mock = $this->createMock(Response::class);
+        $mock->method('hasErrors')->willReturn(false);
+        $mock->method('getData')->willReturn($data);
+        return $mock;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function makeAlertNode(string $packageName): array
+    {
+        $data = require __DIR__ . '/../Fixtures/alert-response.php';
+        $data['securityVulnerability']['package']['name'] = $packageName;
+        return $data;
+    }
+
+    public function testFetchOpenAlertsPaginatesMultiplePages(): void
+    {
+        $page1 = $this->mockResponse([
+            'repository' => [
+                'vulnerabilityAlerts' => [
+                    'pageInfo' => ['hasNextPage' => true, 'endCursor' => 'cursor1'],
+                    'nodes' => [$this->makeAlertNode('lodash')],
+                ],
+            ],
+        ]);
+
+        $page2 = $this->mockResponse([
+            'repository' => [
+                'vulnerabilityAlerts' => [
+                    'pageInfo' => ['hasNextPage' => false, 'endCursor' => 'cursor2'],
+                    'nodes' => [$this->makeAlertNode('axios')],
+                ],
+            ],
+        ]);
+
+        $mockClient = $this->createMock(GraphQLClient::class);
+        $mockClient->expects($this->exactly(2))
+            ->method('query')
+            ->willReturnOnConsecutiveCalls($page1, $page2);
+
+        $config = new Config();
+        $client = new GitHubGraphQLClient($config, $mockClient);
+
+        $alerts = $client->fetchOpenAlerts();
+
+        $this->assertCount(2, $alerts);
+        $this->assertSame('lodash', $alerts[0]['securityVulnerability']['package']['name']);
+        $this->assertSame('axios', $alerts[1]['securityVulnerability']['package']['name']);
+    }
+
+    public function testFetchResolvedAlertsPaginates(): void
+    {
+        $page1 = $this->mockResponse([
+            'repository' => [
+                'vulnerabilityAlerts' => [
+                    'pageInfo' => ['hasNextPage' => true, 'endCursor' => 'c1'],
+                    'nodes' => [
+                        ['state' => 'FIXED', 'number' => 1] + $this->makeAlertNode('pkg-a'),
+                    ],
+                ],
+            ],
+        ]);
+
+        $page2 = $this->mockResponse([
+            'repository' => [
+                'vulnerabilityAlerts' => [
+                    'pageInfo' => ['hasNextPage' => false, 'endCursor' => 'c2'],
+                    'nodes' => [
+                        ['state' => 'DISMISSED', 'number' => 2] + $this->makeAlertNode('pkg-b'),
+                    ],
+                ],
+            ],
+        ]);
+
+        $mockClient = $this->createMock(GraphQLClient::class);
+        $mockClient->expects($this->exactly(2))
+            ->method('query')
+            ->willReturnOnConsecutiveCalls($page1, $page2);
+
+        $config = new Config();
+        $client = new GitHubGraphQLClient($config, $mockClient);
+
+        $alerts = $client->fetchResolvedAlerts();
+        $this->assertCount(2, $alerts);
+    }
+
+    public function testFetchSecurityPullRequestsPaginates(): void
+    {
+        $pr1 = require __DIR__ . '/../Fixtures/pr-response.php';
+        $pr2 = $pr1;
+        $pr2['node']['number'] = '102';
+        $pr2['node']['title'] = 'Bump axios from 0.21.0 to 0.21.1';
+
+        $page1 = $this->mockResponse([
+            'search' => [
+                'issueCount' => 2,
+                'pageInfo' => ['hasNextPage' => true, 'endCursor' => 'pr_c1'],
+                'edges' => [$pr1],
+            ],
+        ]);
+
+        $page2 = $this->mockResponse([
+            'search' => [
+                'issueCount' => 2,
+                'pageInfo' => ['hasNextPage' => false, 'endCursor' => 'pr_c2'],
+                'edges' => [$pr2],
+            ],
+        ]);
+
+        $mockClient = $this->createMock(GraphQLClient::class);
+        $mockClient->expects($this->exactly(2))
+            ->method('query')
+            ->willReturnOnConsecutiveCalls($page1, $page2);
+
+        $config = new Config();
+        $client = new GitHubGraphQLClient($config, $mockClient);
+
+        $prs = $client->fetchSecurityPullRequests();
+        $this->assertCount(2, $prs);
+    }
+
+    public function testSinglePageDoesNotMakeExtraRequests(): void
+    {
+        $response = $this->mockResponse([
+            'repository' => [
+                'vulnerabilityAlerts' => [
+                    'pageInfo' => ['hasNextPage' => false, 'endCursor' => null],
+                    'nodes' => [$this->makeAlertNode('lodash')],
+                ],
+            ],
+        ]);
+
+        $mockClient = $this->createMock(GraphQLClient::class);
+        $mockClient->expects($this->once())
+            ->method('query')
+            ->willReturn($response);
+
+        $config = new Config();
+        $client = new GitHubGraphQLClient($config, $mockClient);
+
+        $alerts = $client->fetchOpenAlerts();
+        $this->assertCount(1, $alerts);
+    }
+}

--- a/tests/Unit/PullRequestIssueTest.php
+++ b/tests/Unit/PullRequestIssueTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira\Tests\Unit;
+
+use GitHubSecurityJira\Config;
+use GitHubSecurityJira\PullRequestIssue;
+use GitHubSecurityJira\SecurityIssueInterface;
+use PHPUnit\Framework\TestCase;
+
+class PullRequestIssueTest extends TestCase
+{
+    /**
+     * @var array<string,string|false>
+     */
+    private array $originalEnv = [];
+
+    protected function setUp(): void
+    {
+        $vars = [
+            'GITHUB_REPOSITORY', 'GH_SECURITY_TOKEN', 'JIRA_HOST',
+            'JIRA_USER', 'JIRA_TOKEN', 'JIRA_PROJECT', 'GITHUB_SERVER_URL',
+            'JIRA_ISSUE_LABELS', 'JIRA_ISSUE_TYPE', 'JIRA_WATCHERS',
+            'JIRA_RESTRICTED_COMMENT_ROLE',
+        ];
+        foreach ($vars as $var) {
+            $this->originalEnv[$var] = \getenv($var);
+        }
+
+        \putenv('GITHUB_REPOSITORY=reload/github-security-jira');
+        \putenv('GH_SECURITY_TOKEN=ghp_test');
+        \putenv('JIRA_HOST=https://test.atlassian.net');
+        \putenv('JIRA_USER=test@example.com');
+        \putenv('JIRA_TOKEN=token');
+        \putenv('JIRA_PROJECT=TEST');
+        \putenv('GITHUB_SERVER_URL=https://github.com');
+        \putenv('JIRA_ISSUE_LABELS');
+        \putenv('JIRA_WATCHERS');
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalEnv as $var => $value) {
+            if ($value === false) {
+                \putenv($var);
+            } else {
+                \putenv("{$var}={$value}");
+            }
+        }
+    }
+
+    public function testImplementsInterface(): void
+    {
+        $data = (require __DIR__ . '/../Fixtures/pr-response.php')['node'];
+        $issue = new PullRequestIssue($data, new Config());
+        $this->assertInstanceOf(SecurityIssueInterface::class, $issue);
+    }
+
+    public function testUniqueIdWithSubdirectory(): void
+    {
+        $data = [
+            'number' => '101',
+            'title' => 'Bump lodash from 4.17.15 to 4.17.21 in /frontend',
+            'url' => 'https://github.com/reload/github-security-jira/pull/101',
+        ];
+
+        $issue = new PullRequestIssue($data, new Config());
+
+        $this->assertSame('lodash:frontend:4.17.21', $issue->uniqueId());
+    }
+
+    public function testUniqueIdWithoutSubdirectory(): void
+    {
+        $data = [
+            'number' => '102',
+            'title' => 'Bump axios from 0.21.0 to 0.21.1',
+            'url' => 'https://github.com/reload/github-security-jira/pull/102',
+        ];
+
+        $issue = new PullRequestIssue($data, new Config());
+
+        $this->assertSame('axios:0.21.1', $issue->uniqueId());
+    }
+
+    public function testRegexParsesPackageName(): void
+    {
+        $data = [
+            'number' => '103',
+            'title' => 'Bump @angular/core from 12.0.0 to 12.0.1 in /frontend',
+            'url' => 'https://github.com/reload/github-security-jira/pull/103',
+        ];
+
+        $issue = new PullRequestIssue($data, new Config());
+
+        $this->assertSame('@angular/core:frontend:12.0.1', $issue->uniqueId());
+    }
+}

--- a/tests/Unit/SecurityAlertIssueTest.php
+++ b/tests/Unit/SecurityAlertIssueTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GitHubSecurityJira\Tests\Unit;
+
+use GitHubSecurityJira\Config;
+use GitHubSecurityJira\SecurityAlertIssue;
+use GitHubSecurityJira\SecurityIssueInterface;
+use PHPUnit\Framework\TestCase;
+
+class SecurityAlertIssueTest extends TestCase
+{
+    /**
+     * @var array<string,string|false>
+     */
+    private array $originalEnv = [];
+
+    protected function setUp(): void
+    {
+        $vars = [
+            'GITHUB_REPOSITORY', 'GH_SECURITY_TOKEN', 'JIRA_HOST',
+            'JIRA_USER', 'JIRA_TOKEN', 'JIRA_PROJECT', 'GITHUB_SERVER_URL',
+            'JIRA_ISSUE_LABELS', 'JIRA_ISSUE_TYPE', 'JIRA_WATCHERS',
+            'JIRA_RESTRICTED_COMMENT_ROLE',
+        ];
+        foreach ($vars as $var) {
+            $this->originalEnv[$var] = \getenv($var);
+        }
+
+        \putenv('GITHUB_REPOSITORY=reload/github-security-jira');
+        \putenv('GH_SECURITY_TOKEN=ghp_test');
+        \putenv('JIRA_HOST=https://test.atlassian.net');
+        \putenv('JIRA_USER=test@example.com');
+        \putenv('JIRA_TOKEN=token');
+        \putenv('JIRA_PROJECT=TEST');
+        \putenv('GITHUB_SERVER_URL=https://github.com');
+        \putenv('JIRA_ISSUE_LABELS');
+        \putenv('JIRA_WATCHERS');
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalEnv as $var => $value) {
+            if ($value === false) {
+                \putenv($var);
+            } else {
+                \putenv("{$var}={$value}");
+            }
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function getAlertData(): array
+    {
+        return require __DIR__ . '/../Fixtures/alert-response.php';
+    }
+
+    public function testImplementsInterface(): void
+    {
+        $issue = new SecurityAlertIssue($this->getAlertData(), new Config());
+        $this->assertInstanceOf(SecurityIssueInterface::class, $issue);
+    }
+
+    public function testUniqueIdWithSafeVersionRootManifest(): void
+    {
+        $data = $this->getAlertData();
+        // Root manifest path: pathinfo dirname resolves to "."
+        $data['vulnerableManifestPath'] = 'package-lock.json';
+
+        $issue = new SecurityAlertIssue($data, new Config());
+
+        $this->assertSame('lodash:4.17.21', $issue->uniqueId());
+    }
+
+    public function testUniqueIdWithSafeVersionSubdirectory(): void
+    {
+        $data = $this->getAlertData();
+        $data['vulnerableManifestPath'] = 'frontend/package-lock.json';
+
+        $issue = new SecurityAlertIssue($data, new Config());
+
+        $this->assertSame('lodash:frontend:4.17.21', $issue->uniqueId());
+    }
+
+    public function testUniqueIdWithoutSafeVersionUsesGhsaId(): void
+    {
+        $data = $this->getAlertData();
+        unset($data['securityVulnerability']['firstPatchedVersion']);
+        $data['vulnerableManifestPath'] = 'package-lock.json';
+
+        $issue = new SecurityAlertIssue($data, new Config());
+
+        $this->assertSame('lodash:GHSA-1234-5678-abcd', $issue->uniqueId());
+    }
+
+    public function testUniqueIdSpacesReplacedWithUnderscores(): void
+    {
+        $data = $this->getAlertData();
+        $data['vulnerableManifestPath'] = 'my dir/package-lock.json';
+
+        $issue = new SecurityAlertIssue($data, new Config());
+
+        $this->assertSame('lodash:my_dir:4.17.21', $issue->uniqueId());
+    }
+}


### PR DESCRIPTION
## Summary

- **Extract Config DTO** — centralizes all `getenv()` calls with validation and readonly properties
- **Two-way sync** — when GitHub alerts are resolved (FIXED/DISMISSED/AUTO_DISMISSED), the corresponding Jira tickets are now automatically closed via workflow transition
- **Extract services** — `GitHubGraphQLClient`, `AlertSyncService`, `JiraTransitionService`, `AlertIdentifier`, `RetryableApiCall` break the monolithic `SyncCommand` into focused, testable classes
- **Add PHPUnit** — 41 tests (unit + integration) covering Config, unique ID generation, GraphQL client, pagination, Jira transitions, and the full closure flow
- **Cursor-based pagination** — no longer capped at 100 alerts/PRs
- **Retry with exponential backoff** — GraphQL and Jira API calls retry up to 3 times on transient failures
- **Remove unused `symfony/yaml`** dependency

## New environment variable

| Variable | Required | Default | Purpose |
|----------|----------|---------|---------|
| `JIRA_CLOSE_TRANSITION` | No | `Done` | Jira workflow transition name for closing resolved alerts |

## New files

| File | Purpose |
|------|---------|
| `src/Config.php` | Readonly config DTO |
| `src/SecurityIssueInterface.php` | Shared interface |
| `src/GitHubGraphQLClient.php` | GitHub GraphQL with pagination |
| `src/AlertSyncService.php` | Core sync logic (open, PRs, close) |
| `src/AlertIdentifier.php` | Shared unique ID builder |
| `src/JiraTransitionService.php` | Jira search + transition |
| `src/RetryableApiCall.php` | Exponential backoff retry |
| `phpunit.xml` | PHPUnit configuration |
| `tests/` | 41 tests across 9 test files |

## Test plan

- [x] `composer exec phpunit` — 41 tests pass
- [x] `phpstan analyse .` — level 8, no errors
- [x] `phpcs -s bin/ src/` — no violations
- [ ] Dry-run against a real repo: `docker compose run --rm ghsec-jira --verbose --dry-run`
- [ ] Live test against a staging Jira project with known resolved alerts
- [ ] Verify CI passes (PHPStan + PHPCS + PHPUnit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)